### PR TITLE
add support for aws certificate manager issued ssl certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.3 (2016-03-15)
+## current (2016-03-15)
 
 - Add support for ACM certificates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3 (2016-03-15)
+
+- Add support for ACM certificates
+
 ## 0.6.2 (2016-02-11)
 
 - Update dependency to include new compatible stacker release 0.6.1

--- a/conf/empire/empire.yaml
+++ b/conf/empire/empire.yaml
@@ -70,7 +70,7 @@ docker_params: &docker_params
   DockerRegistryUser: ${docker_registry_user}
   DockerRegistryPassword: ${docker_registry_password}
   DockerRegistryEmail: ${docker_registry_email}
- 
+
 stacks:
   - name: vpc
     class_path: stacker_blueprints.vpc.VPC
@@ -153,6 +153,7 @@ stacks:
       ImageName: empire
       TrustedNetwork: ${trusted_network_cidr}
       ControllerELBCertName: ${empire_controller_cert_name}
+      ControllerELBCertType: ${empire_controller_cert_type}
       PublicEmpireAppELBSG: empireMinion::PublicEmpireAppELBSG
       PrivateEmpireAppELBSG: empireMinion::PrivateEmpireAppELBSG
       EmpireMinionCluster: empireMinion::MinionECSCluster

--- a/conf/empire/example.env
+++ b/conf/empire/example.env
@@ -50,7 +50,9 @@ empire_minion_instance_type: c4.xlarge
 empire_controller_min_instance_count: 2
 empire_controller_max_instance_count: 2
 # This cert needs to be uploaded into AWS ahead of time, and will be used for
-# the ELB in front of the Empire API
+# the ELB in front of the Empire API.  Use "acm" for AWS Certificate Manager
+# certs, and "iam" or blank for certs uploaded to IAM.
+empire_controller_cert_type: !!str
 empire_controller_cert_name: !!str
 empire_controller_instance_type: m3.medium
 

--- a/stacker_blueprints/asg.py
+++ b/stacker_blueprints/asg.py
@@ -79,7 +79,7 @@ class AutoscalingGroup(Blueprint):
             "SetupELBDNS",
             And(Condition("CreateELB"), Condition("SetupDNS")))
         self.template.add_condition(
-            "UseIAM",
+            "UseIAMCert",
             Not(Equals(Ref("ELBCertType"), "acm")))
 
     def create_security_groups(self):
@@ -134,7 +134,7 @@ class AutoscalingGroup(Blueprint):
         iam_cert = Join("", [
             "arn:aws:iam::", Ref("AWS::AccountId"), ":server-certificate/",
             Ref("ELBCertName")])
-        cert_id = If("UseIAM", iam_cert, acm_cert)
+        cert_id = If("UseIAMCert", iam_cert, acm_cert)
 
         with_ssl = copy.deepcopy(no_ssl)
         with_ssl.append(elb.Listener(

--- a/stacker_blueprints/empire/empire_controller.py
+++ b/stacker_blueprints/empire/empire_controller.py
@@ -74,6 +74,11 @@ class EmpireController(EmpireBase):
             "description": "The SSL certificate name to use on the ELB. Note: "
                            "If this is set, non-HTTPS access is disabled.",
             "default": ""},
+        "ControllerELBCertType": {
+            "type": "String",
+            "description": "The SSL certificate type to use on the ELB. Note: "
+                           "Can be either acm or iam.",
+            "default": ""},
         "PublicEmpireAppELBSG": {
             "type": "AWS::EC2::SecurityGroup::Id",
             "description": "The SG used by the Public App ELBs."},
@@ -174,6 +179,9 @@ class EmpireController(EmpireBase):
         self.template.add_condition(
             "EnableSNSEvents",
             Not(Equals(Ref("EnableSNSEvents"), "false")))
+        self.template.add_condition(
+            "UseIAM",
+            Not(Equals(Ref("ControllerELBCertType"), "acm")))
 
     def create_security_groups(self):
         t = self.template
@@ -224,9 +232,15 @@ class EmpireController(EmpireBase):
             InstanceProtocol='TCP'
         )]
 
-        cert_id = Join("", [
+        # Choose proper certificate source
+        acm_cert = Join("", [
+            "arn:aws:acm:", Ref("AWS::Region"), ":", Ref("AWS::AccountId"),
+            ":certificate/", Ref("ControllerELBCertName")])
+        iam_cert = Join("", [
             "arn:aws:iam::", Ref("AWS::AccountId"), ":server-certificate/",
             Ref("ControllerELBCertName")])
+        cert_id = If("UseIAM", iam_cert, acm_cert)
+
         with_ssl = []
         with_ssl.append(elb.Listener(
             LoadBalancerPort=443,

--- a/stacker_blueprints/empire/empire_controller.py
+++ b/stacker_blueprints/empire/empire_controller.py
@@ -180,7 +180,7 @@ class EmpireController(EmpireBase):
             "EnableSNSEvents",
             Not(Equals(Ref("EnableSNSEvents"), "false")))
         self.template.add_condition(
-            "UseIAM",
+            "UseIAMCert",
             Not(Equals(Ref("ControllerELBCertType"), "acm")))
 
     def create_security_groups(self):
@@ -239,7 +239,7 @@ class EmpireController(EmpireBase):
         iam_cert = Join("", [
             "arn:aws:iam::", Ref("AWS::AccountId"), ":server-certificate/",
             Ref("ControllerELBCertName")])
-        cert_id = If("UseIAM", iam_cert, acm_cert)
+        cert_id = If("UseIAMCert", iam_cert, acm_cert)
 
         with_ssl = []
         with_ssl.append(elb.Listener(


### PR DESCRIPTION
With the advent of AWS Certificate Manager, I thought it'd be nice to have the ability to attach those certs to the ELBs.   

Thanks - 