### PR TITLE
Add test helper for empire stacks

### DIFF
--- a/bin/test-empire
+++ b/bin/test-empire
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This script will read any values defined within a dev.env file and export
+# them as `--env` command line arguments when running stacker commands. This is
+# useful while developing the example empire blueprint because it allows us to
+# have an example.env file with placeholders and comments that will be filled
+# in with the developer's values.
+
+CMD="stacker $1 conf/empire/example.env conf/empire/empire.yaml ${@:2}"
+while read -r line || [[ -n "$line" ]]
+do
+    CMD="$CMD --env $line"
+done < "dev.env"
+
+echo $CMD
+$CMD


### PR DESCRIPTION
This lets you define something like:

```
namespace=mh.empire.dev
external_domain=empire.com
ssh_key_name=<bla>
trusted_network_cidr=0.0.0.0/0
docker_registry_user=<bla>
docker_registry_email=<bla>
docker_registry_password=<bla>
empiredb_user=empire
empiredb_password=SomePasswordHere353422
empire_controller_token_secret=<bla>
empire_environment=dev
```

and then run `./bin/test-empire build` which will populate values within: `conf/empire/example.env`. This lets us keep empty values within that template with comments and only override values we need when testing.