### PR TITLE
Use compatible release versions for all dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ from setuptools import setup, find_packages
 src_dir = os.path.dirname(__file__)
 
 install_requires = [
-    "troposphere==1.7.0",
-    "awacs==0.6.0",
-    "stacker==0.6.3",
+    "troposphere~=1.8.0",
+    "awacs~=0.6.0",
+    "stacker~=0.6.3",
 ]
 
 tests_require = [
-    "nose>=1.0",
-    "mock==1.0.1",
+    "nose~=1.0",
+    "mock~=2.0.0",
 ]
 
 


### PR DESCRIPTION
Use https://www.python.org/dev/peps/pep-0440/#compatible-release to keep dependencies stable between stacker and stacker_blueprints.