### PR TITLE
Upgrading to empire 0.11.0

### DIFF
--- a/conf/empire/README.md
+++ b/conf/empire/README.md
@@ -14,10 +14,10 @@ detail how things will be built. Once the env is to your liking, you can launch
 the environment by running the following command:
 
 ```
-stacker -e conf/empire/example.env -r <region> <namespace> conf/empire/empire.yaml
+stacker build -r <region> <namespace> conf/empire/example.env conf/empire/empire.yaml
 
 # Example:
-stacker -e conf/empire/example.env -r us-east-1 my-unique-namespace conf/empire/empire.yaml
+stacker build -r us-east-1 my-unique-namespace conf/empire/example.env conf/empire/empire.yaml
 ```
 
 Right now it takes around 20-30 minutes to finish bringing up the entire

--- a/conf/empire/empire.yaml
+++ b/conf/empire/empire.yaml
@@ -155,28 +155,39 @@ stacks:
     parameters:
       << : *vpc_parameters
       << : *docker_params
-      DesiredCount: 1
-      TaskMemory: 256
-      TaskCPU: 1024
-      InternalZoneId: vpc::InternalZoneId
       ExternalDomain: ${external_domain}
       TrustedNetwork: ${trusted_network_cidr}
-      ELBCertName: ${empire_controller_cert_name}
-      ELBCertType: ${empire_controller_cert_type}
+      DatabaseHost: empireDB::DBCname
+      DatabaseUser: ${empiredb_user}
+      DatabasePassword: ${empiredb_password}
+      ELBCertName: ${empire_daemon_cert_name}
+      ELBCertType: ${empire_daemon_cert_type}
+      DesiredCount: 1
+      InstanceSecurityGroup: empireController::SecurityGroup
+      InstanceRole: empireController::IAMRole
+      # If you change this, it may require blueprint changes as well to deal
+      # with changes to Environment variables the empire daemon expects/uses
+      DockerImage: remind101/empire:0.11.0
+      Environment: ${empire_environment}
+      GitHubClientId: ${empire_daemon_github_client_id}
+      GitHubClientSecret: ${empire_daemon_github_client_secret}
+      GitHubOrganization: ${empire_daemon_github_organization}
+      # Used for github deploy webhooks
+      GitHubWebhooksSecret: ${empire_daemon_github_webhooks_secret}
+      GitHubDeploymentsEnvironment: ${empire_daemon_github_deployments_environment}
+      TokenSecret: ${empire_daemon_token_secret}
+      LogStreamer: ${empire_daemon_log_streamer}
+      InternalZoneId: vpc::InternalZoneId
       PublicAppELBSG: empireMinion::PublicAppELBSG
       PrivateAppELBSG: empireMinion::PrivateAppELBSG
       MinionCluster: empireMinion::ECSCluster
       ControllerCluster: empireController::ECSCluster
-      DatabaseHost: empireDB::DBCname
-      DatabaseUser: ${empiredb_user}
-      DatabasePassword: ${empiredb_password}
-      GithubClientId: ${empire_controller_github_client_id}
-      GithubClientSecret: ${empire_controller_github_client_secret}
-      GithubOrganization: ${empire_controller_github_organization}
-      Environment: ${empire_environment}
-      InstanceRole: empireController::IAMRole
-      InstanceSecurityGroup: empireController::SecurityGroup
-      # Used for github deploy webhooks
-      GithubWebhooksSecret: ${empire_controller_github_webhooks_secret}
-      GithubDeploymentsEnvironment: ${empire_controller_github_deployments_environment}
-      TokenSecret: ${empire_controller_token_secret}
+      RunLogsBackend: ${empire_daemon_run_logs_backend}
+      RunLogsCloudwatchGroup: !!str
+      EventsBackend: ${empire_daemon_events_backend}
+      EventsSNSTopicName: ${empire_daemon_events_sns_topic_name}
+      TaskMemory: 256
+      TaskCPU: 1024
+      AwsDebug: ${empire_daemon_aws_debug}
+      ServiceMaximumPercent: 200
+      ServiceMinimumHealthyPercent: 50

--- a/conf/empire/empire.yaml
+++ b/conf/empire/empire.yaml
@@ -154,7 +154,6 @@ stacks:
     class_path: stacker_blueprints.empire.daemon.EmpireDaemon
     parameters:
       << : *vpc_parameters
-      << : *docker_params
       ExternalDomain: ${external_domain}
       TrustedNetwork: ${trusted_network_cidr}
       DatabaseHost: empireDB::DBCname
@@ -176,7 +175,7 @@ stacks:
       GitHubWebhooksSecret: ${empire_daemon_github_webhooks_secret}
       GitHubDeploymentsEnvironment: ${empire_daemon_github_deployments_environment}
       TokenSecret: ${empire_daemon_token_secret}
-      LogStreamer: ${empire_daemon_log_streamer}
+      LogsStreamer: ${empire_daemon_log_streamer}
       InternalZoneId: vpc::InternalZoneId
       PublicAppELBSG: empireMinion::PublicAppELBSG
       PrivateAppELBSG: empireMinion::PrivateAppELBSG
@@ -191,3 +190,4 @@ stacks:
       AwsDebug: ${empire_daemon_aws_debug}
       ServiceMaximumPercent: 200
       ServiceMinimumHealthyPercent: 50
+      RequireCommitMessages: ${empire_daemon_require_commit_messages}

--- a/conf/empire/empire.yaml
+++ b/conf/empire/empire.yaml
@@ -168,6 +168,7 @@ stacks:
       # with changes to Environment variables the empire daemon expects/uses
       DockerImage: remind101/empire:0.11.0
       Environment: ${empire_environment}
+      EmpireScheduler: ${empire_daemon_scheduler}
       GitHubClientId: ${empire_daemon_github_client_id}
       GitHubClientSecret: ${empire_daemon_github_client_secret}
       GitHubOrganization: ${empire_daemon_github_organization}

--- a/conf/empire/example.env
+++ b/conf/empire/example.env
@@ -35,6 +35,7 @@ docker_registry_email:
 # Disk size for RDS instance in GB
 empiredb_disk_size: 10
 empiredb_instance_type: db.m3.large
+
 # This username & password will be created automatically on the empire
 # database, and will be shared with Empire
 empiredb_user:
@@ -47,32 +48,55 @@ empire_minion_min_instance_count: 3
 empire_minion_max_instance_count: 10
 empire_minion_instance_type: c4.xlarge
 
+empire_environment: example
+
 empire_controller_min_instance_count: 2
 empire_controller_max_instance_count: 2
+empire_controller_instance_type: m3.medium
+
 # This cert needs to be uploaded into AWS ahead of time, and will be used for
 # the ELB in front of the Empire API.  Use "acm" for AWS Certificate Manager
 # certs, and "iam" or blank for certs uploaded to IAM.
-empire_controller_cert_type: !!str
-empire_controller_cert_name: !!str
-empire_controller_instance_type: m3.medium
+empire_daemon_cert_type: !!str
+empire_daemon_cert_name: !!str
 
 # This is used for github authentication - you need to setup a new Oauth
 # application in Github in your github organization
 # https://github.com/organizations/:organization/settings/applications
 # See: http://empire.readthedocs.org/en/latest/configuration/#github-authentication
-empire_controller_github_client_id:
-empire_controller_github_client_secret:
-empire_controller_github_organization:
+empire_daemon_github_client_id:
+empire_daemon_github_client_secret:
+empire_daemon_github_organization:
+
 # This is used for github deployment webhooks. See:
 # http://empire.readthedocs.org/en/latest/configuration/#github-deployments
 # Disabled by default (!!str is a blank string)
-empire_controller_github_webhooks_secret: !!str
-empire_controller_github_deployments_environment: !!str
+empire_daemon_github_webhooks_secret: !!str
+empire_daemon_github_deployments_environment: !!str
 
 # Just a random string used to sign access tokens for clients in Empire
 # should be somewhere between 32-64 characters long
-empire_controller_token_secret:
+empire_daemon_token_secret:
 
-# Set to true to enable sending empire events to SNS (disabled by default)
-# Will create an SNS topic for you automatically
-empire_controller_enable_sns_events: !!str false
+# Set to an empty string to disable sending empire daemon events to the
+# application logstream (via kinesis)
+empire_daemon_log_streamer: kinesis
+
+# Where to send the empire daemon logs - sends to cloudwatch. Can also be
+# set to 'stdout' if you only want to send it to stdout on each controller
+empire_daemon_run_logs_backend: cloudwatch
+
+# If empire_daemon_run_logs_backend is set to cloudwatch, you can set this
+# to the name of an existing cloudwatch log group to send the logs there. If
+# an empty string, a new cloudwatch log group will be created for you
+empire_daemon_run_logs_cloudwatch_group: !!str
+
+# Set to SNS if you want to send all empire daemon events into an SNS topic
+empire_daemon_events_backend: stdout
+
+# If empire_daemon_events_backend is set to SNS, set this if you want to use
+# an existing SNS topic. If not provided, an SNS topic will be created for you
+empire_daemon_events_sns_topic_name: !!str
+
+# Set to true to enable debug logging from the AWS SDK library
+empire_daemon_aws_debug: false

--- a/conf/empire/example.env
+++ b/conf/empire/example.env
@@ -100,3 +100,7 @@ empire_daemon_events_sns_topic_name: !!str
 
 # Set to true to enable debug logging from the AWS SDK library
 empire_daemon_aws_debug: false
+
+# Set to true to require commit messages for certain commands:
+# run, set, restart, deploy, etc
+empire_daemon_require_commit_messages: false

--- a/conf/empire/example.env
+++ b/conf/empire/example.env
@@ -104,3 +104,6 @@ empire_daemon_aws_debug: false
 # Set to true to require commit messages for certain commands:
 # run, set, restart, deploy, etc
 empire_daemon_require_commit_messages: false
+
+# The scheduler to use in Empire
+empire_daemon_scheduler: cloudformation-migration

--- a/stacker_blueprints/empire/daemon.py
+++ b/stacker_blueprints/empire/daemon.py
@@ -115,6 +115,13 @@ class EmpireDaemon(Blueprint):
         "Environment": {
             "type": "String",
             "description": "Environment used for Empire."},
+        "EmpireScheduler": {
+            "type": "String",
+            "description": (
+                "The scheduler for Empire to use. Defaults to "
+                "cloudformation-migration"
+            ),
+            "default": "cloudformation-migration"},
         "GitHubClientId": {
             "type": "String",
             "description": "EMPIRE_GITHUB_CLIENT_ID",
@@ -414,7 +421,7 @@ class EmpireDaemon(Blueprint):
                 Value=Ref("Environment")),
             ecs.Environment(
                 Name="EMPIRE_SCHEDULER",
-                Value="cloudformation-migration"),
+                Value=Ref("EmpireScheduler")),
             ecs.Environment(
                 Name="EMPIRE_REPORTER",
                 Value=Ref("Reporter")),

--- a/stacker_blueprints/empire/daemon.py
+++ b/stacker_blueprints/empire/daemon.py
@@ -214,13 +214,6 @@ class EmpireDaemon(Blueprint):
                 "The number of MiB to reserve for the empire daemon task."
             ),
             "default": "1024"},
-        "AwsDebug": {
-            "type": "String",
-            "description": (
-                "Boolean for whether or not to enable AWS debug logs."
-            ),
-            "allowed_values": ["true", "false"],
-            "default": "false"},
         "TaskCPU": {
             "type": "Number",
             "description": (
@@ -228,6 +221,13 @@ class EmpireDaemon(Blueprint):
                 "task."
             ),
             "default": "1024"},
+        "AwsDebug": {
+            "type": "String",
+            "description": (
+                "Boolean for whether or not to enable AWS debug logs."
+            ),
+            "allowed_values": ["true", "false"],
+            "default": "false"},
         "ServiceMaximumPercent": {
             "type": "Number",
             "description": (
@@ -474,6 +474,9 @@ class EmpireDaemon(Blueprint):
             ecs.Environment(
                 Name="EMPIRE_EC2_SUBNETS_PUBLIC",
                 Value=Join(",", Ref("PublicSubnets"))),
+            ecs.Environment(
+                Name='EMPIRE_ELB_VPC_ID',
+                Value=Ref('VpcId')),
             ecs.Environment(
                 Name="EMPIRE_ELB_SG_PRIVATE",
                 Value=Ref("PrivateAppELBSG")),

--- a/stacker_blueprints/empire/daemon.py
+++ b/stacker_blueprints/empire/daemon.py
@@ -243,7 +243,13 @@ class EmpireDaemon(Blueprint):
                 "the Amazon ECS service's DesiredCount value, that must "
                 "continue to run and remain healthy during a deployment."
             ),
-            "default": "50"}
+            "default": "50"},
+        "RequireCommitMessages": {
+            "type": "String",
+            "description": "Enables requiring commit messages if set to "
+                           "'true'.",
+            'default': "false",
+        }
     }
 
     def create_template(self):
@@ -280,6 +286,9 @@ class EmpireDaemon(Blueprint):
         t.add_condition(
             "EnableAppEventStream",
             Equals(Ref("LogsStreamer"), "kinesis"))
+        t.add_condition(
+            "RequireCommitMessages",
+            Equals(Ref("RequireCommitMessages"), "true"))
 
     def create_security_groups(self):
         t = self.template
@@ -504,6 +513,11 @@ class EmpireDaemon(Blueprint):
                     "EnableCloudwatchLogs",
                     Ref(RUN_LOGS),
                     "AWS::NoValue")),
+            If(
+                'RequireCommitMessages',
+                ecs.Environment(Name='EMPIRE_MESSAGES_REQUIRED', Value='true'),
+                Ref('AWS::NoValue')
+            ),
         ]
 
     def create_ecs_resources(self):

--- a/stacker_blueprints/empire/minion.py
+++ b/stacker_blueprints/empire/minion.py
@@ -140,6 +140,15 @@ class EmpireMinion(EmpireBase):
                     SourceSecurityGroupId=Ref(group_name),
                     GroupId=Ref(CLUSTER_SG_NAME)))
 
+            # When using Application Load Balancing, the port is chosen at
+            # random within an ephemeral port range.
+            t.add_resource(
+                ec2.SecurityGroupIngress(
+                    "Empire%sAppPort32768To61000" % elb.capitalize(),
+                    IpProtocol="tcp", FromPort=32768, ToPort=61000,
+                    SourceSecurityGroupId=Ref(group_name),
+                    GroupId=Ref(CLUSTER_SG_NAME)))
+
             # Allow anything to talk to the ELB
             # If internal only internal hosts will be able to talk to
             # the elb

--- a/stacker_blueprints/empire/policies.py
+++ b/stacker_blueprints/empire/policies.py
@@ -1,8 +1,10 @@
 import logging
 
 from awacs import (
+    awslambda,
     ecs,
     ec2,
+    events,
     iam,
     route53,
     kinesis,
@@ -73,7 +75,11 @@ def empire_policy(resources):
             Statement(
                 Effect=Allow,
                 Resource=[resources['CustomResourcesQueue']],
-                Action=[sqs.ReceiveMessage, sqs.DeleteMessage]),
+                Action=[
+                    sqs.ReceiveMessage,
+                    sqs.DeleteMessage,
+                    sqs.ChangeMessageVisibility
+                ]),
             Statement(
                 Effect=Allow,
                 Resource=[resources['TemplateBucket']],
@@ -85,6 +91,27 @@ def empire_policy(resources):
                     s3.GetObjectVersion,
                     s3.GetObjectAcl,
                     s3.GetObjectVersionAcl]),
+            Statement(
+                Effect=Allow,
+                Resource=["*"],
+                Action=[
+                    awslambda.CreateFunction,
+                    awslambda.DeleteFunction,
+                    awslambda.UpdateFunctionCode,
+                    awslambda.GetFunctionConfiguration,
+                    awslambda.AddPermission,
+                    awslambda.RemovePermission]),
+            Statement(
+                Effect=Allow,
+                Resource=["*"],
+                Action=[
+                    events.PutRule,
+                    events.DeleteRule,
+                    events.DescribeRule,
+                    events.EnableRule,
+                    events.DisableRule,
+                    events.PutTargets,
+                    events.RemoveTargets]),
             Statement(
                 Effect=Allow,
                 Resource=[
@@ -147,7 +174,8 @@ def empire_policy(resources):
                 Action=[
                     kinesis.DescribeStream,
                     Action(kinesis.prefix, "Get*"),
-                    Action(kinesis.prefix, "List*")
+                    Action(kinesis.prefix, "List*"),
+                    kinesis.PutRecord,
                 ],
                 Resource=["*"]),
         ]

--- a/stacker_blueprints/empire/policies.py
+++ b/stacker_blueprints/empire/policies.py
@@ -151,6 +151,7 @@ def empire_policy(resources):
                 Resource=["*"],
                 Action=[
                     elb.Action("Describe*"),
+                    elb.AddTags,
                     elb.CreateLoadBalancer,
                     elb.DescribeTags,
                     elb.DeleteLoadBalancer,

--- a/stacker_blueprints/empire/policies.py
+++ b/stacker_blueprints/empire/policies.py
@@ -61,7 +61,13 @@ def service_role_policy():
                     Action("ec2", "Describe*"),
                     elb.DeregisterInstancesFromLoadBalancer,
                     Action("elasticloadbalancing", "Describe*"),
-                    elb.RegisterInstancesWithLoadBalancer])])
+                    elb.RegisterInstancesWithLoadBalancer,
+                    elb.Action("RegisterTargets"),
+                    elb.Action("DeregisterTargets"),
+                ]
+            )
+        ]
+    )
     return p
 
 
@@ -143,12 +149,23 @@ def empire_policy(resources):
                 Effect=Allow,
                 # TODO: Limit to specific ELB?
                 Resource=["*"],
-                Action=[elb.DeleteLoadBalancer, elb.CreateLoadBalancer,
-                        elb.DescribeLoadBalancers, elb.DescribeTags,
-                        elb.ConfigureHealthCheck,
-                        elb.ModifyLoadBalancerAttributes,
-                        elb.SetLoadBalancerListenerSSLCertificate,
-                        elb.SetLoadBalancerPoliciesOfListener]),
+                Action=[
+                    elb.Action("Describe*"),
+                    elb.CreateLoadBalancer,
+                    elb.DescribeTags,
+                    elb.DeleteLoadBalancer,
+                    elb.ConfigureHealthCheck,
+                    elb.ModifyLoadBalancerAttributes,
+                    elb.SetLoadBalancerListenerSSLCertificate,
+                    elb.SetLoadBalancerPoliciesOfListener,
+                    elb.Action("CreateTargetGroup"),
+                    elb.Action("CreateListener"),
+                    elb.Action("DeleteListener"),
+                    elb.Action("DeleteTargetGroup"),
+                    elb.Action("ModifyTargetGroup"),
+                    elb.Action("ModifyTargetGroupAttributes"),
+                ]
+            ),
             Statement(
                 Effect=Allow,
                 Resource=["*"],


### PR DESCRIPTION
This also locks the default config to 0.11.0, while providing the option
to change it (but with a comment declaring this will likely require
blueprint updates).

- Fully updates config & exmaple env to allow for all the new features
- moves env variables from empire_controller -> empire_daemon where
  appropriate
- Fixes github captilization issue
- Adds new IAM permissions for new empire features (lambda, events, etc)