### PR TITLE
Add new, low-level security group rule blueprint

### DIFF
--- a/stacker_blueprints/security_rules.py
+++ b/stacker_blueprints/security_rules.py
@@ -7,7 +7,7 @@ CLASS_MAP = {
 }
 
 
-class SecurityGroupRules(Blueprint):
+class Rules(Blueprint):
     """Used to add Ingress/Egress rules to existing security groups.
 
     This blueprint uses two variables:
@@ -23,7 +23,7 @@ class SecurityGroupRules(Blueprint):
     An example:
 
     name: mySecurityRules
-    class_path: stacker_blueprints.security_rules.SecurityGroupRules
+    class_path: stacker_blueprints.security_rules.Rules
     variables:
       IngressRules:
         All80ToWebserverGroup:
@@ -41,7 +41,8 @@ class SecurityGroupRules(Blueprint):
                            "name of the rule to create, and the value is "
                            "a dictionary of keys/values based on the "
                            "attributes of the "
-                           "troposphere.ec2.SecurityGroupIngress class.",
+                           ":class:`troposphere.ec2.SecurityGroupIngress` "
+                           "class.",
             "default": {},
         },
         "EgressRules": {
@@ -50,7 +51,8 @@ class SecurityGroupRules(Blueprint):
                            "name of the rule to create, and the value is "
                            "a dictionary of keys/values based on the "
                            "attributes of the "
-                           "troposphere.ec2.SecurityGroupEgress class.",
+                           ":class:`troposphere.ec2.SecurityGroupEgress` "
+                           "class.",
             "default": {},
         }
     }

--- a/stacker_blueprints/security_rules.py
+++ b/stacker_blueprints/security_rules.py
@@ -1,0 +1,61 @@
+from troposphere.ec2 import SecurityGroupIngress, SecurityGroupEgress
+from stacker.blueprints.base import Blueprint
+
+CLASS_MAP = {
+    "IngressRules": SecurityGroupIngress,
+    "EgressRules": SecurityGroupEgress,
+}
+
+
+class SecurityGroupRules(Blueprint):
+    """Used to add Ingress/Egress rules to existing security groups.
+
+    This blueprint uses two variables:
+        IngressRules:
+            A dict with keys of the virtual titles for each rule, and with the
+            value being a dict of the parameters taken directly from:
+                http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html
+        EgressRules:
+            A dict with keys of the virtual titles for each rule, and with the
+            value being a dict of the parameters taken directly from:
+                http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-security-group-egress.html
+
+    An example:
+
+    name: mySecurityRules
+    class_path: stacker_blueprints.security_rules.SecurityGroupRules
+    variables:
+      IngressRules:
+        All80ToWebserverGroup:
+          CidrIp: 0.0.0.0/0
+          FromPort: 80
+          ToPort: 80
+          GroupId: ${output WebserverStack::SecurityGroup}
+          IpProtocol: tcp
+    """
+
+    VARIABLES = {
+        "IngressRules": {
+            "type": dict,
+            "description": "A dict of ingress rules where the key is the "
+                           "name of the rule to create, and the value is "
+                           "a dictionary of keys/values based on the "
+                           "attributes of the "
+                           "troposphere.ec2.SecurityGroupIngress class.",
+        },
+        "EgressRules": {
+            "type": dict,
+            "description": "A dict of ingress rules where the key is the "
+                           "name of the rule to create, and the value is "
+                           "a dictionary of keys/values based on the "
+                           "attributes of the "
+                           "troposphere.ec2.SecurityGroupEgress class.",
+        }
+    }
+
+    def create_template(self):
+        t = self.template
+        variables = self.get_variables()
+        for rule_type, rule_class in CLASS_MAP.items():
+            for rule_title, rule_attrs in variables[rule_type]:
+                t.add_resource(rule_class.from_dict(rule_title, rule_attrs))

--- a/stacker_blueprints/security_rules.py
+++ b/stacker_blueprints/security_rules.py
@@ -42,6 +42,7 @@ class SecurityGroupRules(Blueprint):
                            "a dictionary of keys/values based on the "
                            "attributes of the "
                            "troposphere.ec2.SecurityGroupIngress class.",
+            "default": {},
         },
         "EgressRules": {
             "type": dict,
@@ -50,12 +51,16 @@ class SecurityGroupRules(Blueprint):
                            "a dictionary of keys/values based on the "
                            "attributes of the "
                            "troposphere.ec2.SecurityGroupEgress class.",
+            "default": {},
         }
     }
 
-    def create_template(self):
+    def create_security_rules(self):
         t = self.template
         variables = self.get_variables()
         for rule_type, rule_class in CLASS_MAP.items():
-            for rule_title, rule_attrs in variables[rule_type]:
+            for rule_title, rule_attrs in variables[rule_type].items():
                 t.add_resource(rule_class.from_dict(rule_title, rule_attrs))
+
+    def create_template(self):
+        self.create_security_rules()


### PR DESCRIPTION
This should make it super simple to have a stack that
maintains security group rules on security groups built in other
stacks. Mostly useful for rules that glue two stacks together
(like adding a rule to allow instances in your webserver stack to
talk to your RDS database on the right port)
