### PR TITLE
Relax troposphere dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ from setuptools import setup, find_packages
 src_dir = os.path.dirname(__file__)
 
 install_requires = [
-    "troposphere~=1.8.2",
-    "awacs~=0.6.0",
     "stacker~=0.8.1",
 ]
 


### PR DESCRIPTION
To allow this to be used with the latest version of stacker, which currently depends on troposphere 1.9 (fixing in https://github.com/remind101/stacker/pull/276).