### PR TITLE
Make elasticache Subnets work like RDS Subnets

### DIFF
--- a/stacker_blueprints/elasticache/base.py
+++ b/stacker_blueprints/elasticache/base.py
@@ -38,7 +38,7 @@ class BaseReplicationGroup(Blueprint):
             "description": "Vpc Id to place the Cluster in"
         },
         "Subnets": {
-            "type": list,
+            "type": str,
             "description": "Comma separated list of subnets to deploy the "
                            "Cluster nodes in."
         },
@@ -199,7 +199,7 @@ class BaseReplicationGroup(Blueprint):
             SubnetGroup(
                 SUBNET_GROUP,
                 Description="%s subnet group." % self.name,
-                SubnetIds=self.get_variables()["Subnets"]))
+                SubnetIds=self.get_variables()["Subnets"].split(',')))
 
     def create_security_group(self):
         t = self.template


### PR DESCRIPTION
The list type Variable couldn't take the output from a VPC blueprint:

Subnets: ${xref ${base_stack_name}-vpc::PrivateSubnets}