### PR TITLE
Add the FifoQueue parameter to sqs.Queues

### DIFF
--- a/stacker_blueprints/sqs.py
+++ b/stacker_blueprints/sqs.py
@@ -26,9 +26,8 @@ def validate_queue(queue):
     if "RedrivePolicy" in queue:
         queue["RedrivePolicy"] = sqs.RedrivePolicy(**queue["RedrivePolicy"])
 
-    if "FifoQueue" in queue and queue["FifoQueue"]:
-        if "QueueName" not in queue or \
-                not queue["QueueName"].endswith(".fifo"):
+    if queue.get("FifoQueue"):
+        if not queue.get("QueueName", "").endswith(".fifo"):
             raise ValueError(
                 "FIFO queues need to provide a QueueName "
                 "that ends with '.fifo'"

--- a/stacker_blueprints/sqs.py
+++ b/stacker_blueprints/sqs.py
@@ -26,6 +26,14 @@ def validate_queue(queue):
     if "RedrivePolicy" in queue:
         queue["RedrivePolicy"] = sqs.RedrivePolicy(**queue["RedrivePolicy"])
 
+    if "FifoQueue" in queue and queue["FifoQueue"]:
+        if "QueueName" not in queue or \
+                not queue["QueueName"].endswith(".fifo"):
+            raise ValueError(
+                "FIFO queues need to provide a QueueName "
+                "that ends with '.fifo'"
+            )
+
     return queue
 
 

--- a/stacker_blueprints/sqs.py
+++ b/stacker_blueprints/sqs.py
@@ -13,6 +13,7 @@ from . import util
 def validate_queue(queue):
     sqs_queue_properties = [
         "DelaySeconds",
+        "FifoQueue",
         "MaximumMessageSize",
         "MessageRetentionPeriod",
         "ReceiveMessageWaitTimeSeconds",


### PR DESCRIPTION
Add the FifoQueue parameter from CloudFormation:
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html#cfn-sqs-queue-fifoqueue
as a variable to sqs.Queque.

Please note that this parameter requires Replacement on update.