### PR TITLE
add generic resource creator

### DIFF
--- a/stacker_blueprints/generic.py
+++ b/stacker_blueprints/generic.py
@@ -5,6 +5,7 @@ from troposphere import (
 
 from stacker.blueprints.base import Blueprint
 
+
 class GenericResourceCreator(Blueprint):
     """ Generic Blueprint for creating a resource """
     def add_cfn_description(self):
@@ -32,7 +33,8 @@ class GenericResourceCreator(Blueprint):
              'description': 'The output to create'},
         'Properties':
             {'type': dict,
-             'description': 'The list of propertie to use for the troposphere class'},
+             'description': 'The list of propertie to use for the troposphere'
+                            + ' class'},
     }
 
     def setup_resource(self):

--- a/stacker_blueprints/generic.py
+++ b/stacker_blueprints/generic.py
@@ -27,14 +27,16 @@ class GenericResourceCreator(Blueprint):
     VARIABLES = {
         'Class':
             {'type': str,
-             'description': 'The troposphere class to create, e.g. ec2.Volume'},
+             'description': 'The troposphere class to create, '
+                            'e.g.: ec2.Volume'},
         'Output':
             {'type': str,
-             'description': 'The output field that should be created, e.g. VolumeId'},
+             'description': 'The output field that should be created, '
+                            'e.g.: VolumeId'},
         'Properties':
             {'type': dict,
-             'description': 'The list of properties to use for the troposphere '
-                            'class'},
+             'description': 'The list of properties to use for the '
+                            'Troposphere class'},
     }
 
     """
@@ -53,7 +55,6 @@ class GenericResourceCreator(Blueprint):
                 AvailabilityZone: us-east-1b
 
     """
-
 
     def setup_resource(self):
         """ Setting Up Resource """

--- a/stacker_blueprints/generic.py
+++ b/stacker_blueprints/generic.py
@@ -64,17 +64,14 @@ class GenericResourceCreator(Blueprint):
 
         klass = load_object_from_string('troposphere.' + tclass)
 
-        # we need to do the following because of type conversion issues -
-        # Troposphere expects strings, but stacker automatically converts
-        # to types such as Number, etc.  In the future, it'd be nice to
-        # have a variables_raw or something like that which just keeps
-        # the plain string from the yaml
+        # Warning - sometimes, Troposhpere expects a datatype
+        # that is strange, for example ec2.Volume.Size expects
+        # to be a string.  In those cases, you should make a PR
+        # with Troposhpere to fix it, but as a workaround you 
+        # can quote the value in the yaml to force detection
+        # as a string
 
-        tprops_string = {}
-        for variable, value in tprops.items():
-            tprops_string[variable] = str(value)
-
-        instance = klass.from_dict('ResourceRefName', tprops_string)
+        instance = klass.from_dict('ResourceRefName', tprops)
 
         template.add_resource(instance)
         template.add_output(Output(

--- a/stacker_blueprints/generic.py
+++ b/stacker_blueprints/generic.py
@@ -1,0 +1,77 @@
+""" Load dependencies """
+from troposphere import (
+    Ref, Output
+)
+
+from stacker.blueprints.base import Blueprint
+from stacker.blueprints.variables.types import (
+    CFNString,
+    CFNCommaDelimitedList,
+)
+
+class generic_resource_creator(Blueprint):
+    """ Generic Blueprint for creating a resource """
+    def add_cfn_description(self):
+        """ Boilerplate for CFN Template """
+        template = self.template
+        template.add_version('2010-09-09')
+        template.add_description('Generic Resource Creator - 1.0.0')
+
+    """
+
+    *** NOTE ***    Template Version Reminder
+
+    Make Sure you bump up the template version number above if submitting
+    updates to the repo. This is the only way we can tell which version of
+    a template is in place on a running resouce.
+
+    """
+
+    VARIABLES = {
+        'Class':
+            {'type': str,
+             'description': 'The troposphere class to create'},
+        'Output':
+            {'type': str,
+             'description': 'The output to create'},
+        'Properties':
+            {'type': dict,
+             'description': 'The list of propertie to use for the troposphere class'},
+    }
+
+    def setup_resource(self):
+        template = self.template
+        variables = self.get_variables()
+
+        tclass = variables['Class']
+        tprops = variables['Properties']
+        output = variables['Output']
+
+        klass = self.get_class('troposphere.' + tclass)
+
+        # we need to do the following because of type conversion issues
+        tprops_string = {}
+        for variable, value in tprops.items():
+          tprops_string[variable] = str(value)
+
+        instance = klass.from_dict('ResourceRefName', tprops_string)
+
+        template.add_resource(instance)
+        template.add_output(Output(
+            output,
+            Description="The output",
+            Value=Ref(instance)
+        ))
+
+    def create_template(self):
+        """ Create the CFN template """
+        self.add_cfn_description()
+        self.setup_resource()
+
+    def get_class(self, kls):
+        parts = kls.split('.')
+        module = ".".join(parts[:-1])
+        m = __import__( module )
+        for comp in parts[1:]:
+            m = getattr(m, comp)            
+        return m

--- a/stacker_blueprints/generic.py
+++ b/stacker_blueprints/generic.py
@@ -4,18 +4,14 @@ from troposphere import (
 )
 
 from stacker.blueprints.base import Blueprint
-from stacker.blueprints.variables.types import (
-    CFNString,
-    CFNCommaDelimitedList,
-)
 
-class generic_resource_creator(Blueprint):
+class GenericResourceCreator(Blueprint):
     """ Generic Blueprint for creating a resource """
     def add_cfn_description(self):
         """ Boilerplate for CFN Template """
         template = self.template
         template.add_version('2010-09-09')
-        template.add_description('Generic Resource Creator - 1.0.0')
+        template.add_description('CGM Generic Resource Creator - 1.0.0')
 
     """
 
@@ -40,6 +36,7 @@ class generic_resource_creator(Blueprint):
     }
 
     def setup_resource(self):
+        """ Setting Up Resource """
         template = self.template
         variables = self.get_variables()
 
@@ -52,7 +49,7 @@ class generic_resource_creator(Blueprint):
         # we need to do the following because of type conversion issues
         tprops_string = {}
         for variable, value in tprops.items():
-          tprops_string[variable] = str(value)
+            tprops_string[variable] = str(value)
 
         instance = klass.from_dict('ResourceRefName', tprops_string)
 
@@ -69,9 +66,10 @@ class generic_resource_creator(Blueprint):
         self.setup_resource()
 
     def get_class(self, kls):
+        """ Get class function """
         parts = kls.split('.')
         module = ".".join(parts[:-1])
-        m = __import__( module )
+        mod = __import__(module)
         for comp in parts[1:]:
-            m = getattr(m, comp)            
-        return m
+            mod = getattr(mod, comp)
+        return mod

--- a/stacker_blueprints/generic.py
+++ b/stacker_blueprints/generic.py
@@ -67,7 +67,7 @@ class GenericResourceCreator(Blueprint):
         # Warning - sometimes, Troposhpere expects a datatype
         # that is strange, for example ec2.Volume.Size expects
         # to be a string.  In those cases, you should make a PR
-        # with Troposhpere to fix it, but as a workaround you 
+        # with Troposhpere to fix it, but as a workaround you
         # can quote the value in the yaml to force detection
         # as a string
 

--- a/stacker_blueprints/generic.py
+++ b/stacker_blueprints/generic.py
@@ -22,6 +22,20 @@ class GenericResourceCreator(Blueprint):
     updates to the repo. This is the only way we can tell which version of
     a template is in place on a running resouce.
 
+
+    Example yaml:
+
+    - name: generic-resource-volume
+        class_path: blueprints.generic.GenericResourceCreator
+        variables:
+            Class: ec2.Volume
+            Output: VolumeId
+            Properties:
+                VolumeType: gp2
+                Size: 5
+                Encrypted: true
+                AvailabilityZone: us-east-1b
+
     """
 
     VARIABLES = {
@@ -38,23 +52,6 @@ class GenericResourceCreator(Blueprint):
              'description': 'The list of properties to use for the '
                             'Troposphere class'},
     }
-
-    """
-
-    Example yaml:
-
-    - name: generic-resource-volume
-        class_path: blueprints.generic.GenericResourceCreator
-        variables:
-            Class: ec2.Volume
-            Output: VolumeId
-            Properties:
-                VolumeType: gp2
-                Size: 5
-                Encrypted: true
-                AvailabilityZone: us-east-1b
-
-    """
 
     def setup_resource(self):
         """ Setting Up Resource """

--- a/tests/fixtures/blueprints/test_generic_GenericResourceCreator.json
+++ b/tests/fixtures/blueprints/test_generic_GenericResourceCreator.json
@@ -1,0 +1,23 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Generic Resource Creator - 1.0.0",
+    "Outputs": {
+        "VolumeId": {
+            "Description": "A reference to the object created in this blueprint",
+            "Value": {
+                "Ref": "ResourceRefName"
+            }
+        }
+    },
+    "Resources": {
+        "ResourceRefName": {
+            "Properties": {
+                "AvailabilityZone": "us-east-1b",
+                "Encrypted": "true",
+                "Size": "600",
+                "VolumeType": "gp2"
+            },
+            "Type": "AWS::EC2::Volume"
+        }
+    }
+}

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -22,7 +22,7 @@ class TestGenericResourceCreator(BlueprintTestCase):
                     'Size': '600',
                     'Encrypted': 'true',
                     'AvailabilityZone': 'us-east-1b',
-                }
+                }),
             ]
         )
         blueprint.create_template()

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -12,7 +12,7 @@ class TestGenericResourceCreator(BlueprintTestCase):
         self.ctx = Context({'namespace': 'test'})
 
     def test_create_template(self):
-        blueprint = Function('test_generic_GenericResourceCreator', self.ctx)
+        blueprint = GenericResourceCreator('test_generic_GenericResourceCreator', self.ctx)
         blueprint.resolve_variables(
             [
                 Variable('Class', 'ec2.Volume'),

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -7,7 +7,7 @@ from stacker.variables import Variable
 from stacker_blueprints.generic import GenericResourceCreator
 
 
-class TestFunction(BlueprintTestCase):
+class TestGenericResourceCreator(BlueprintTestCase):
     def setUp(self):
         self.ctx = Context({'namespace': 'test'})
 

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,0 +1,33 @@
+import unittest
+
+from stacker.blueprints.testutil import BlueprintTestCase
+from stacker.context import Context
+from stacker.variables import Variable
+
+from stacker_blueprints.generic import GenericResourceCreator
+
+
+class TestFunction(BlueprintTestCase):
+    def setUp(self):
+        self.ctx = Context({'namespace': 'test'})
+
+    def test_create_template(self):
+        blueprint = Function('test_generic_GenericResourceCreator', self.ctx)
+        blueprint.resolve_variables(
+            [
+                Variable('Class', 'ec2.Volume'),
+                Variable('Output', 'VolumeId'),
+                Variable('Properties', {
+                    'VolumeType': 'gp2',
+                    'Size': '600',
+                    'Encrypted': 'true',
+                    'AvailabilityZone': 'us-east-1b',
+                }
+            ]
+        )
+        blueprint.create_template()
+        self.assertRenderedBlueprint(blueprint)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Example yaml:

  - name: generic-resource-volume
    class_path: blueprints.generic.GenericResourceCreator
    variables:
      Class: ec2.Volume
      Output: VolumeId
      Properties:
          VolumeType: gp2
          Size: 5
          Encrypted: true
          AvailabilityZone: us-east-1b
