### PR TITLE
Skip record_set if 'Enabled' key is False

### DIFF
--- a/stacker_blueprints/route53.py
+++ b/stacker_blueprints/route53.py
@@ -72,7 +72,8 @@ class DNSRecords(Blueprint):
         "RecordSets": {
             "type": list,
             "description": "A list of dictionaries representing the attributes"
-                           "of a troposphere.route53.RecordSetType object.",
+                           "of a troposphere.route53.RecordSetType object."
+                           "Also accepts an optional 'Enabled' boolean.",
             "default": []
         },
     }
@@ -103,7 +104,11 @@ class DNSRecords(Blueprint):
         Return list of record_set objects."""
         record_set_objects = []
         for record_set_dict in record_set_dicts:
-            record_set_objects.append(self.create_record_set(record_set_dict))
+            # pop removes the 'Enabled' key and tests if True.
+            if record_set_dict.pop('Enabled', True):
+                record_set_objects.append(
+                    self.create_record_set(record_set_dict)
+                )
         return record_set_objects
 
     def create_template(self):

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -52,13 +52,21 @@ class TestRoute53(BlueprintTestCase):
                             "ResourceRecords": ["10.0.0.2"],
                             "Comment": "This is host2's record. : )",
                         },
+                        {
+                            "Name": "host3.testdomain.com.",
+                            "Type": "A",
+                            "ResourceRecords": ["10.0.0.3"],
+                            "Comment": "This record is present but disabled.",
+                            "Enabled": False,
+                        },
                     ]
                 ),
                 Variable("HostedZoneName", "testdomain.com"),
                 Variable("Comment", "test-testdomain-com"),
             ]
         )
-        blueprint.create_template()
+        record_sets = blueprint.create_template()
+        self.assertEqual(2, len(record_sets))
         self.assertRenderedBlueprint(blueprint)
 
     def test_cloudfront_alias_adds_hosted_zone_id(self):


### PR DESCRIPTION
	modified:   stacker_blueprints/route53.py
	modified:   tests/test_route53.py