### PR TITLE
Make A and CNAME sum to same label.

### DIFF
--- a/stacker_blueprints/route53.py
+++ b/stacker_blueprints/route53.py
@@ -40,6 +40,10 @@ ELB_DOMAIN = ".elb.amazonaws.com."
 
 def get_record_set_md5(rs_name, rs_type):
     """Accept record_set Name and Type. Return MD5 sum of these values."""
+    rs_name = rs_name.lower()
+    rs_type = rs_type.upper()
+    # Make A and CNAME records hash to same sum to support updates.
+    rs_type = "ACNAME" if rs_type in ["A", "CNAME"] else rs_type
     return md5(rs_name + rs_type).hexdigest()
 
 

--- a/tests/fixtures/blueprints/route53_dnsrecords.json
+++ b/tests/fixtures/blueprints/route53_dnsrecords.json
@@ -5,7 +5,7 @@
         }
     },
     "Resources": {
-        "b42885d94c1ece3681f457bcb9b3e2f5": {
+        "154ad64949b7d01dc1d117e306f5ef2c": {
             "Properties": {
                 "HostedZoneId": "fake_zone_id",
                 "Name": "host2.testdomain.com.",
@@ -16,7 +16,7 @@
             },
             "Type": "AWS::Route53::RecordSet"
         },
-        "fa483a19f88c93a25d8185959159fa2e": {
+        "d8df5bad0c9f04ee2c1f12f25a46a67c": {
             "Properties": {
                 "HostedZoneId": "fake_zone_id",
                 "Name": "host.testdomain.com.",

--- a/tests/fixtures/blueprints/route53_dnsrecords_zone_name.json
+++ b/tests/fixtures/blueprints/route53_dnsrecords_zone_name.json
@@ -20,16 +20,7 @@
         }
     },
     "Resources": {
-        "HostedZone": {
-            "Properties": {
-                "HostedZoneConfig": {
-                    "Comment": "test-testdomain-com"
-                },
-                "Name": "testdomain.com"
-            },
-            "Type": "AWS::Route53::HostedZone"
-        },
-        "b42885d94c1ece3681f457bcb9b3e2f5": {
+        "154ad64949b7d01dc1d117e306f5ef2c": {
             "Properties": {
                 "Comment": "This is host2's record. : )",
                 "HostedZoneId": {
@@ -43,7 +34,16 @@
             },
             "Type": "AWS::Route53::RecordSet"
         },
-        "fa483a19f88c93a25d8185959159fa2e": {
+        "HostedZone": {
+            "Properties": {
+                "HostedZoneConfig": {
+                    "Comment": "test-testdomain-com"
+                },
+                "Name": "testdomain.com"
+            },
+            "Type": "AWS::Route53::HostedZone"
+        },
+        "d8df5bad0c9f04ee2c1f12f25a46a67c": {
             "Properties": {
                 "HostedZoneId": {
                     "Ref": "HostedZone"

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -1,7 +1,10 @@
 from stacker.context import Context
 from stacker.variables import Variable
 
-from stacker_blueprints.route53 import DNSRecords
+from stacker_blueprints.route53 import (
+  DNSRecords,
+  get_record_set_md5,
+)
 
 from stacker.blueprints.testutil import BlueprintTestCase
 
@@ -176,6 +179,31 @@ class TestRoute53(BlueprintTestCase):
         )
         with self.assertRaises(ValueError):
             blueprint.create_template()
+
+    def test_get_record_set_md5(self):
+        rs_name = "www.example.com"
+        self.assertEqual(
+            get_record_set_md5(rs_name, "A"),
+            get_record_set_md5(rs_name, "A")
+        )
+        self.assertNotEqual(
+            get_record_set_md5(rs_name, "A"),
+            get_record_set_md5(rs_name, "MX")
+        )
+
+    def test_get_record_set_md5_a_and_cname_same_sum(self):
+        rs_name = "www.example.com"
+        self.assertEqual(
+            get_record_set_md5(rs_name, "A"),
+            get_record_set_md5(rs_name, "CNAME")
+        )
+
+    def test_get_record_set_md5_caps_in_name_same_sum(self):
+        rs_name = "www.example.com"
+        self.assertEqual(
+            get_record_set_md5(rs_name, "A"),
+            get_record_set_md5("Www.Example.Com", "A")
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This has been manually tested and I was able to switch a record set from
A to CNAME and back to A (AliasTarget).

This will cause a CNAME and a A record to have the same "label" or logical id
so that changing the Type of a record will work as an update instead of an add/remove (which actually doesn't work)

CNAMEs and A records still both work as expected and but are now interchangeable without causing an error.

WARNING: This is not backwards compatible