### PR TITLE
Correctly test sqs.Queue parameters in sqs.py

### DIFF
--- a/stacker_blueprints/sqs.py
+++ b/stacker_blueprints/sqs.py
@@ -11,17 +11,7 @@ from . import util
 
 
 def validate_queue(queue):
-    sqs_queue_properties = [
-        "DelaySeconds",
-        "FifoQueue",
-        "MaximumMessageSize",
-        "MessageRetentionPeriod",
-        "ReceiveMessageWaitTimeSeconds",
-        "RedrivePolicy",
-        "VisibilityTimeout",
-    ]
-
-    util.check_properties(queue, sqs_queue_properties, "SQS")
+    util.check_properties(queue, sqs.Queue.props.keys(), "SQS")
 
     if "RedrivePolicy" in queue:
         queue["RedrivePolicy"] = sqs.RedrivePolicy(**queue["RedrivePolicy"])

--- a/tests/fixtures/blueprints/queues.json
+++ b/tests/fixtures/blueprints/queues.json
@@ -1,0 +1,71 @@
+{
+    "Outputs": {
+        "FifoArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Fifo",
+                    "Arn"
+                ]
+            }
+        },
+        "FifoUrl": {
+            "Value": {
+                "Ref": "Fifo"
+            }
+        },
+        "RedrivePolicyArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "RedrivePolicy",
+                    "Arn"
+                ]
+            }
+        },
+        "RedrivePolicyUrl": {
+            "Value": {
+                "Ref": "RedrivePolicy"
+            }
+        },
+        "SimpleArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Simple",
+                    "Arn"
+                ]
+            }
+        },
+        "SimpleUrl": {
+            "Value": {
+                "Ref": "Simple"
+            }
+        }
+    },
+    "Resources": {
+        "Fifo": {
+            "Properties": {
+                "FifoQueue": true,
+                "QueueName": "Fifo.fifo"
+            },
+            "Type": "AWS::SQS::Queue"
+        },
+        "RedrivePolicy": {
+            "Properties": {
+                "RedrivePolicy": {
+                    "deadLetterTargetArn": "arn:aws:sqs:us-east-1:123456789:dlq",
+                    "maxReceiveCount": 3
+                }
+            },
+            "Type": "AWS::SQS::Queue"
+        },
+        "Simple": {
+            "Properties": {
+                "DelaySeconds": 15,
+                "FifoQueue": false,
+                "MaximumMessageSize": 4096,
+                "ReceiveMessageWaitTimeSeconds": 15,
+                "VisibilityTimeout": 600
+            },
+            "Type": "AWS::SQS::Queue"
+        }
+    }
+}

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -1,0 +1,35 @@
+import unittest
+from stacker.context import Context
+from stacker.variables import Variable
+from stacker_blueprints.sqs import Queues
+from stacker.blueprints.testutil import BlueprintTestCase
+
+class TestBlueprint(BlueprintTestCase):
+    def setUp(self):
+        self.variables = [
+            Variable('Queues', {
+                'Simple': {
+                    'DelaySeconds': 15,
+                    'FifoQueue': False,
+                    'MaximumMessageSize': 4096,
+                    'ReceiveMessageWaitTimeSeconds': 15,
+                    'VisibilityTimeout': 600,
+                },
+                'Fifo': {
+                    'FifoQueue': True,
+                    'QueueName': 'Fifo.fifo',
+                },
+                'RedrivePolicy': {
+                    'RedrivePolicy': {
+                        'deadLetterTargetArn': 'arn:aws:sqs:us-east-1:123456789:dlq',
+                        'maxReceiveCount': 3,
+                    }
+                }})
+        ]
+
+    def test_sqs(self):
+        ctx = Context({'namespace': 'test', 'environment': 'test'})
+        blueprint = Queues('queues', ctx)
+        blueprint.resolve_variables(self.variables)
+        blueprint.create_template()
+        self.assertRenderedBlueprint(blueprint)


### PR DESCRIPTION
`validate_parameters()` has a fixed list of valid sqs.Queue parameters which is not in sync with troposphere.

Notably, it lacks `QueueName`, which makes it fail when using FifoQueue=True -- since FifoQueue requires a name set. `QueueName` should have been added in https://github.com/remind101/stacker_blueprints/pull/118 -- this merge solves that and also tries to prevent this type of error in the future by using the keys from sqs.Queue.props for checking instead of listing parameters.

Also add a test for sqs.py.