### PR TITLE
Use TroposphereType in sqs.py

### DIFF
--- a/stacker_blueprints/sqs.py
+++ b/stacker_blueprints/sqs.py
@@ -1,4 +1,5 @@
 from stacker.blueprints.base import Blueprint
+from stacker.blueprints.variables.types import TroposphereType
 
 from troposphere import (
     sqs,
@@ -7,71 +8,24 @@ from troposphere import (
     Output,
 )
 
-from . import util
-
-
-def validate_queue(queue):
-    sqs_queue_properties = [
-        "DelaySeconds",
-        "FifoQueue",
-        "MaximumMessageSize",
-        "MessageRetentionPeriod",
-        "ReceiveMessageWaitTimeSeconds",
-        "RedrivePolicy",
-        "VisibilityTimeout",
-    ]
-
-    util.check_properties(queue, sqs_queue_properties, "SQS")
-
-    if "RedrivePolicy" in queue:
-        queue["RedrivePolicy"] = sqs.RedrivePolicy(**queue["RedrivePolicy"])
-
-    if queue.get("FifoQueue"):
-        if not queue.get("QueueName", "").endswith(".fifo"):
-            raise ValueError(
-                "FIFO queues need to provide a QueueName "
-                "that ends with '.fifo'"
-            )
-
-    return queue
-
-
-def validate_queues(queues):
-    validated_queues = {}
-    for queue_name, queue_config in queues.iteritems():
-        validated_queues[queue_name] = validate_queue(queue_config)
-
-    return validated_queues
-
 
 class Queues(Blueprint):
     """Manages the creation of SQS queues."""
 
     VARIABLES = {
         "Queues": {
-            "type": dict,
+            "type": TroposphereType(sqs.Queue, many=True),
             "description": "Dictionary of SQS queue definitions",
-            "validator": validate_queues,
         },
     }
 
     def create_template(self):
+        t = self.template
         variables = self.get_variables()
 
-        for name, queue_config in variables["Queues"].iteritems():
-            self.create_queue(name, queue_config)
-
-    def create_queue(self, queue_name, queue_config):
-        t = self.template
-
-        t.add_resource(
-            sqs.Queue(
-                queue_name,
-                **queue_config
+        for queue in variables["Queues"]:
+            t.add_resource(queue)
+            t.add_output(
+                Output(queue.title + "Arn", Value=GetAtt(queue, "Arn"))
             )
-        )
-
-        t.add_output(
-            Output(queue_name + "Arn", Value=GetAtt(queue_name, "Arn"))
-        )
-        t.add_output(Output(queue_name + "Url", Value=Ref(queue_name)))
+            t.add_output(Output(queue.title + "Url", Value=Ref(queue)))

--- a/tests/fixtures/blueprints/queues.json
+++ b/tests/fixtures/blueprints/queues.json
@@ -1,5 +1,18 @@
 {
     "Outputs": {
+        "FifoArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Fifo",
+                    "Arn"
+                ]
+            }
+        },
+        "FifoUrl": {
+            "Value": {
+                "Ref": "Fifo"
+            }
+        },
         "RedrivePolicyArn": {
             "Value": {
                 "Fn::GetAtt": [
@@ -28,6 +41,13 @@
         }
     },
     "Resources": {
+        "Fifo": {
+            "Properties": {
+                "FifoQueue": true,
+                "QueueName": "Fifo.fifo"
+            },
+            "Type": "AWS::SQS::Queue"
+        },
         "RedrivePolicy": {
             "Properties": {
                 "RedrivePolicy": {

--- a/tests/fixtures/blueprints/queues.json
+++ b/tests/fixtures/blueprints/queues.json
@@ -1,0 +1,50 @@
+{
+    "Outputs": {
+        "RedrivePolicyArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "RedrivePolicy",
+                    "Arn"
+                ]
+            }
+        },
+        "RedrivePolicyUrl": {
+            "Value": {
+                "Ref": "RedrivePolicy"
+            }
+        },
+        "SimpleArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Simple",
+                    "Arn"
+                ]
+            }
+        },
+        "SimpleUrl": {
+            "Value": {
+                "Ref": "Simple"
+            }
+        }
+    },
+    "Resources": {
+        "RedrivePolicy": {
+            "Properties": {
+                "RedrivePolicy": {
+                    "deadLetterTargetArn": "arn:aws:sqs:us-east-1:123456789:dlq",
+                    "maxReceiveCount": 3
+                }
+            },
+            "Type": "AWS::SQS::Queue"
+        },
+        "Simple": {
+            "Properties": {
+                "DelaySeconds": 15,
+                "MaximumMessageSize": 4096,
+                "ReceiveMessageWaitTimeSeconds": 15,
+                "VisibilityTimeout": 600
+            },
+            "Type": "AWS::SQS::Queue"
+        }
+    }
+}

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -1,0 +1,30 @@
+import unittest
+from stacker.context import Context
+from stacker.variables import Variable
+from stacker_blueprints.sqs import Queues
+from stacker.blueprints.testutil import BlueprintTestCase
+
+class TestBlueprint(BlueprintTestCase):
+    def setUp(self):
+        self.variables = [
+            Variable('Queues', {
+                'Simple': {
+                    'DelaySeconds': 15,
+                    'MaximumMessageSize': 4096,
+                    'ReceiveMessageWaitTimeSeconds': 15,
+                    'VisibilityTimeout': 600,
+                },
+                'RedrivePolicy': {
+                    'RedrivePolicy': {
+                        'deadLetterTargetArn': 'arn:aws:sqs:us-east-1:123456789:dlq',
+                        'maxReceiveCount': 3,
+                    }
+                }})
+        ]
+
+    def test_sqs(self):
+        ctx = Context({'namespace': 'test', 'environment': 'test'})
+        blueprint = Queues('queues', ctx)
+        blueprint.resolve_variables(self.variables)
+        blueprint.create_template()
+        self.assertRenderedBlueprint(blueprint)

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -14,6 +14,10 @@ class TestBlueprint(BlueprintTestCase):
                     'ReceiveMessageWaitTimeSeconds': 15,
                     'VisibilityTimeout': 600,
                 },
+                'Fifo': {
+                    'FifoQueue': True,
+                    'QueueName': 'Fifo.fifo',
+                },
                 'RedrivePolicy': {
                     'RedrivePolicy': {
                         'deadLetterTargetArn': 'arn:aws:sqs:us-east-1:123456789:dlq',


### PR DESCRIPTION
Instead of local validation, use TroposphereType for loading the
queues in sqs.py.

Also add a test for sqs.py.

This supersedes https://github.com/remind101/stacker_blueprints/pull/131.