### PR TITLE
Fixes troposphere dependency conflicts w/ stacker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,15 @@ from setuptools import setup, find_packages
 src_dir = os.path.dirname(__file__)
 
 install_requires = [
-    "stacker~=1.0.1",
-    "troposphere~=1.9.5",
+    "stacker>=1.0.1",
+    "troposphere>=1.9.5",
+    "awacs>=0.6.0",
 ]
 
 tests_require = [
-    "nose~=1.0",
+    "nose",
     "mock~=2.0.0",
+    "stacker>=1.1.1",
 ]
 
 

--- a/stacker_blueprints/rds/base.py
+++ b/stacker_blueprints/rds/base.py
@@ -33,9 +33,8 @@ def validate_db_instance_identifier(value, allow_empty=True):
     if not value and allow_empty:
         # Empty value will pick up default from stackname
         return value
-    l = len(value)
     pattern = r"^[a-zA-Z][a-zA-Z0-9-]*$"
-    if not (0 < l < 64):
+    if not (0 < len(value) < 64):
         raise ValueError("Must be between 1 and 63 characters in length.")
     if not re.match(pattern, value):
         raise ValueError("Must match pattern: %s" % pattern)

--- a/tests/test_aws_lambda.py
+++ b/tests/test_aws_lambda.py
@@ -1,6 +1,7 @@
 from types import MethodType
 
 from stacker.context import Context
+from stacker.config import Config
 from stacker.variables import Variable
 from stacker_blueprints.aws_lambda import Function, FunctionScheduler
 from stacker.blueprints.testutil import BlueprintTestCase
@@ -25,7 +26,7 @@ class TestBlueprint(BlueprintTestCase):
             "Runtime": "python2.7",
             "Timeout": 3,
         }
-        self.ctx = Context({'namespace': 'test', 'environment': 'test'})
+        self.ctx = Context(config=Config({'namespace': 'test'}))
 
     def create_blueprint(self, name):
         return Function(name, self.ctx)

--- a/tests/test_cloudwatch_logs.py
+++ b/tests/test_cloudwatch_logs.py
@@ -2,6 +2,7 @@ import unittest
 
 from stacker.blueprints.testutil import BlueprintTestCase
 from stacker.context import Context
+from stacker.config import Config
 from stacker.variables import Variable
 
 from stacker_blueprints.cloudwatch_logs import SubscriptionFilters
@@ -11,7 +12,7 @@ from troposphere import GetAtt, Ref
 
 class TestSubscriptionFilters(BlueprintTestCase):
     def setUp(self):
-        self.ctx = Context({'namespace': 'test'})
+        self.ctx = Context(config=Config({'namespace': 'test'}))
 
     def test_create_template(self):
         blueprint = SubscriptionFilters(

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -2,6 +2,7 @@ import unittest
 
 from stacker.blueprints.testutil import BlueprintTestCase
 from stacker.context import Context
+from stacker.config import Config
 from stacker.variables import Variable
 
 from stacker_blueprints.generic import GenericResourceCreator
@@ -9,10 +10,12 @@ from stacker_blueprints.generic import GenericResourceCreator
 
 class TestGenericResourceCreator(BlueprintTestCase):
     def setUp(self):
-        self.ctx = Context({'namespace': 'test'})
+        self.ctx = Context(config=Config({'namespace': 'test'}))
 
     def test_create_template(self):
-        blueprint = GenericResourceCreator('test_generic_GenericResourceCreator', self.ctx)
+        blueprint = GenericResourceCreator(
+            'test_generic_GenericResourceCreator', self.ctx
+        )
         blueprint.resolve_variables(
             [
                 Variable('Class', 'ec2.Volume'),

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -1,4 +1,5 @@
 from stacker.context import Context
+from stacker.config import Config
 from stacker.variables import Variable
 
 from stacker_blueprints.kms import Key
@@ -8,7 +9,7 @@ from stacker.blueprints.testutil import BlueprintTestCase
 
 class TestKmsKey(BlueprintTestCase):
     def setUp(self):
-        self.ctx = Context({'namespace': 'test'})
+        self.ctx = Context(config=Config({'namespace': 'test'}))
 
     def test_kms_key(self):
         blueprint = Key('kms_key_a', self.ctx)
@@ -31,7 +32,7 @@ class TestKmsKey(BlueprintTestCase):
         )
         blueprint.create_template()
         self.assertRenderedBlueprint(blueprint)
-    
+
     def test_kms_key_without_properties(self):
         blueprint = Key('kms_key_c', self.ctx)
         blueprint.resolve_variables(
@@ -52,7 +53,3 @@ class TestKmsKey(BlueprintTestCase):
         )
         with self.assertRaises(DeprecationWarning):
             blueprint.create_template()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -1,4 +1,5 @@
 from stacker.context import Context
+from stacker.config import Config
 from stacker.variables import Variable
 
 from stacker_blueprints.route53 import (
@@ -8,9 +9,10 @@ from stacker_blueprints.route53 import (
 
 from stacker.blueprints.testutil import BlueprintTestCase
 
+
 class TestRoute53(BlueprintTestCase):
     def setUp(self):
-        self.ctx = Context({'namespace': 'test'})
+        self.ctx = Context(config=Config({'namespace': 'test'}))
 
     def test_create_template_hosted_zone_id(self):
         blueprint = DNSRecords('route53_dnsrecords', self.ctx)
@@ -92,10 +94,12 @@ class TestRoute53(BlueprintTestCase):
             ]
         )
         record_sets = blueprint.create_template()
-        self.assertEqual(record_sets[0].AliasTarget.HostedZoneId, "Z2FDTNDATAQYW2")
+        self.assertEqual(record_sets[0].AliasTarget.HostedZoneId,
+                         "Z2FDTNDATAQYW2")
 
     def test_elb_alias_proper_hosted_zone_id(self):
-        blueprint = DNSRecords('test_route53_elb_alias_hosted_zone_id', self.ctx)
+        blueprint = DNSRecords('test_route53_elb_alias_hosted_zone_id',
+                               self.ctx)
         blueprint.resolve_variables(
             [
                 Variable(
@@ -105,7 +109,7 @@ class TestRoute53(BlueprintTestCase):
                             "Name": "host.testdomain.com.",
                             "Type": "A",
                             "AliasTarget": {
-                                "DNSName": "myelb-1234567890-abcdef.us-east-2.elb.amazonaws.com.",
+                                "DNSName": "myelb-1234567890-abcdef.us-east-2.elb.amazonaws.com.",  # noqa
                             },
                         },
                     ]


### PR DESCRIPTION
This should make it easier to deal with dependency conflicts with common
libraries with stacker, primarily troposphere.

It also updates tests so they are compatible with stacker 1.1.1, while
allowing the regular run time to work with any stacker installation
greater than 1.0.1