### PR TITLE
Add *Acl permissions in RW buckets

### DIFF
--- a/stacker_blueprints/policies.py
+++ b/stacker_blueprints/policies.py
@@ -58,31 +58,16 @@ def read_only_s3_bucket_policy(buckets):
 
 
 def read_write_s3_bucket_policy_statements(buckets):
-    list_buckets = [s3_arn(b) for b in buckets]
     object_buckets = [s3_arn(Join("/", [b, "*"])) for b in buckets]
-    return [
-        Statement(
-            Effect="Allow",
-            Action=[
-                s3.GetBucketLocation,
-                s3.ListAllMyBuckets,
-            ],
-            Resource=["arn:aws:s3:::*"]
-        ),
+    return read_only_s3_bucket_policy_statements(buckets) + [
         Statement(
             Effect=Allow,
             Action=[
-                s3.ListBucket,
-            ],
-            Resource=list_buckets,
-        ),
-        Statement(
-            Effect=Allow,
-            Action=[
-                s3.GetObject,
                 s3.PutObject,
                 s3.PutObjectAcl,
+                s3.PutObjectVersionAcl,
                 s3.DeleteObject,
+                s3.DeleteObjectVersion,
             ],
             Resource=object_buckets,
         ),

--- a/tests/fixtures/blueprints/buckets.json
+++ b/tests/fixtures/blueprints/buckets.json
@@ -173,17 +173,25 @@
                     "Statement": [
                         {
                             "Action": [
-                                "s3:GetBucketLocation", 
                                 "s3:ListAllMyBuckets"
                             ], 
                             "Effect": "Allow", 
                             "Resource": [
-                                "arn:aws:s3:::*"
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            "*"
+                                        ]
+                                    ]
+                                }
                             ]
                         }, 
                         {
                             "Action": [
-                                "s3:ListBucket"
+                                "s3:Get*", 
+                                "s3:List*"
                             ], 
                             "Effect": "Allow", 
                             "Resource": [
@@ -208,15 +216,54 @@
                                             }
                                         ]
                                     ]
+                                }, 
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            {
+                                                "Fn::Join": [
+                                                    "/", 
+                                                    [
+                                                        {
+                                                            "Ref": "Simple"
+                                                        }, 
+                                                        "*"
+                                                    ]
+                                                ]
+                                            }
+                                        ]
+                                    ]
+                                }, 
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            {
+                                                "Fn::Join": [
+                                                    "/", 
+                                                    [
+                                                        {
+                                                            "Ref": "Cycle"
+                                                        }, 
+                                                        "*"
+                                                    ]
+                                                ]
+                                            }
+                                        ]
+                                    ]
                                 }
                             ]
                         }, 
                         {
                             "Action": [
-                                "s3:GetObject", 
                                 "s3:PutObject", 
                                 "s3:PutObjectAcl", 
-                                "s3:DeleteObject"
+                                "s3:PutObjectVersionAcl", 
+                                "s3:DeleteObject", 
+                                "s3:DeleteObjectVersion"
                             ], 
                             "Effect": "Allow", 
                             "Resource": [

--- a/tests/fixtures/blueprints/buckets.json
+++ b/tests/fixtures/blueprints/buckets.json
@@ -1,0 +1,277 @@
+{
+    "Outputs": {
+        "CycleBucketArn": {
+            "Value": {
+                "Fn::Join": [
+                    "", 
+                    [
+                        "arn:aws:s3:::", 
+                        {
+                            "Ref": "Cycle"
+                        }
+                    ]
+                ]
+            }
+        }, 
+        "CycleBucketDomainName": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Cycle", 
+                    "DomainName"
+                ]
+            }
+        }, 
+        "CycleBucketId": {
+            "Value": {
+                "Ref": "Cycle"
+            }
+        }, 
+        "SimpleBucketArn": {
+            "Value": {
+                "Fn::Join": [
+                    "", 
+                    [
+                        "arn:aws:s3:::", 
+                        {
+                            "Ref": "Simple"
+                        }
+                    ]
+                ]
+            }
+        }, 
+        "SimpleBucketDomainName": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Simple", 
+                    "DomainName"
+                ]
+            }
+        }, 
+        "SimpleBucketId": {
+            "Value": {
+                "Ref": "Simple"
+            }
+        }
+    }, 
+    "Resources": {
+        "Cycle": {
+            "Properties": {
+                "LifecycleConfiguration": {
+                    "Rules": [
+                        {
+                            "ExpirationInDays": 40, 
+                            "Status": "Enabled"
+                        }
+                    ]
+                }
+            }, 
+            "Type": "AWS::S3::Bucket"
+        }, 
+        "ReadPolicy": {
+            "Properties": {
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "s3:ListAllMyBuckets"
+                            ], 
+                            "Effect": "Allow", 
+                            "Resource": [
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            "*"
+                                        ]
+                                    ]
+                                }
+                            ]
+                        }, 
+                        {
+                            "Action": [
+                                "s3:Get*", 
+                                "s3:List*"
+                            ], 
+                            "Effect": "Allow", 
+                            "Resource": [
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            {
+                                                "Ref": "Simple"
+                                            }
+                                        ]
+                                    ]
+                                }, 
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            {
+                                                "Ref": "Cycle"
+                                            }
+                                        ]
+                                    ]
+                                }, 
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            {
+                                                "Fn::Join": [
+                                                    "/", 
+                                                    [
+                                                        {
+                                                            "Ref": "Simple"
+                                                        }, 
+                                                        "*"
+                                                    ]
+                                                ]
+                                            }
+                                        ]
+                                    ]
+                                }, 
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            {
+                                                "Fn::Join": [
+                                                    "/", 
+                                                    [
+                                                        {
+                                                            "Ref": "Cycle"
+                                                        }, 
+                                                        "*"
+                                                    ]
+                                                ]
+                                            }
+                                        ]
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }, 
+                "PolicyName": "test-bucketsReadPolicy", 
+                "Roles": [
+                    "Role1", 
+                    "Role2"
+                ]
+            }, 
+            "Type": "AWS::IAM::Policy"
+        }, 
+        "ReadWritePolicy": {
+            "Properties": {
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "s3:GetBucketLocation", 
+                                "s3:ListAllMyBuckets"
+                            ], 
+                            "Effect": "Allow", 
+                            "Resource": [
+                                "arn:aws:s3:::*"
+                            ]
+                        }, 
+                        {
+                            "Action": [
+                                "s3:ListBucket"
+                            ], 
+                            "Effect": "Allow", 
+                            "Resource": [
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            {
+                                                "Ref": "Simple"
+                                            }
+                                        ]
+                                    ]
+                                }, 
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            {
+                                                "Ref": "Cycle"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            ]
+                        }, 
+                        {
+                            "Action": [
+                                "s3:GetObject", 
+                                "s3:PutObject", 
+                                "s3:PutObjectAcl", 
+                                "s3:DeleteObject"
+                            ], 
+                            "Effect": "Allow", 
+                            "Resource": [
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            {
+                                                "Fn::Join": [
+                                                    "/", 
+                                                    [
+                                                        {
+                                                            "Ref": "Simple"
+                                                        }, 
+                                                        "*"
+                                                    ]
+                                                ]
+                                            }
+                                        ]
+                                    ]
+                                }, 
+                                {
+                                    "Fn::Join": [
+                                        "", 
+                                        [
+                                            "arn:aws:s3:::", 
+                                            {
+                                                "Fn::Join": [
+                                                    "/", 
+                                                    [
+                                                        {
+                                                            "Ref": "Cycle"
+                                                        }, 
+                                                        "*"
+                                                    ]
+                                                ]
+                                            }
+                                        ]
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }, 
+                "PolicyName": "test-bucketsReadWritePolicy", 
+                "Roles": [
+                    "Role3", 
+                    "Role4"
+                ]
+            }, 
+            "Type": "AWS::IAM::Policy"
+        }, 
+        "Simple": {
+            "Type": "AWS::S3::Bucket"
+        }
+    }
+}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,0 +1,37 @@
+import unittest
+from stacker.context import Context, Config
+from stacker.variables import Variable
+from stacker_blueprints.s3 import Buckets
+from stacker.blueprints.testutil import BlueprintTestCase
+
+
+class TestBlueprint(BlueprintTestCase):
+    def setUp(self):
+        self.variables = [
+            Variable('Buckets', {
+                'Simple': {},
+                'Cycle': {
+                    'LifecycleConfiguration': {
+                        'Rules': [{
+                            'Status': 'Enabled',
+                            'ExpirationInDays': 40,
+                        }],
+                    },
+                }
+            }),
+            Variable('ReadRoles', [
+                'Role1',
+                'Role2',
+            ]),
+            Variable('ReadWriteRoles', [
+                'Role3',
+                'Role4',
+            ]),
+        ]
+
+    def test_s3(self):
+        ctx = Context(config=Config({'namespace': 'test'}))
+        blueprint = Buckets('buckets', ctx)
+        blueprint.resolve_variables(self.variables)
+        blueprint.create_template()
+        self.assertRenderedBlueprint(blueprint)


### PR DESCRIPTION
Adds GetObjectAcl, PutObjectAcl and some others into RW s3 buckets in s3.py.

Also refactors the RW permissions to extend from the RO permissions, to avoid duplication and different sets of permissions -- for example, RO had GetObjectAcl but RW hadn't.

Also add a test for s3.py.