### PR TITLE
Create sqs policies only for sqs-type topic subscriptions

### DIFF
--- a/stacker_blueprints/sns.py
+++ b/stacker_blueprints/sns.py
@@ -133,5 +133,6 @@ class Topics(Blueprint):
         )
         t.add_output(Output(topic_name + "Arn", Value=topic_arn))
 
-        if topic_subs:
-            self.create_sqs_policy(topic_name, topic_arn, topic_subs)
+        sqs_subs = [sub for sub in topic_subs if sub["Protocol"] == "sqs"]
+        if sqs_subs:
+            self.create_sqs_policy(topic_name, topic_arn, sqs_subs)

--- a/tests/fixtures/blueprints/topics.json
+++ b/tests/fixtures/blueprints/topics.json
@@ -1,0 +1,64 @@
+{
+    "Outputs": {
+        "ExampleArn": {
+            "Value": {
+                "Ref": "Example"
+            }
+        }, 
+        "ExampleName": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Example", 
+                    "TopicName"
+                ]
+            }
+        }
+    }, 
+    "Resources": {
+        "Example": {
+            "Properties": {
+                "DisplayName": "ExampleTopic", 
+                "Subscription": [
+                    {
+                        "Endpoint": "arn:aws:sqs:us-east-1:123456788901:example-queue", 
+                        "Protocol": "sqs"
+                    }, 
+                    {
+                        "Endpoint": "postmaster@example.com", 
+                        "Protocol": "email"
+                    }
+                ]
+            }, 
+            "Type": "AWS::SNS::Topic"
+        }, 
+        "ExampleSubPolicy": {
+            "Properties": {
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sqs:SendMessage"
+                            ], 
+                            "Condition": {
+                                "ArnEquals": {
+                                    "aws:SourceArn": {
+                                        "Ref": "Example"
+                                    }
+                                }
+                            }, 
+                            "Effect": "Allow", 
+                            "Principal": "*", 
+                            "Resource": [
+                                "arn:aws:sqs:us-east-1:123456788901:example-queue"
+                            ]
+                        }
+                    ]
+                }, 
+                "Queues": [
+                    "https://sqs.us-east-1.amazonaws.com/123456788901/example-queue"
+                ]
+            }, 
+            "Type": "AWS::SQS::QueuePolicy"
+        }
+    }
+}

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -1,0 +1,32 @@
+import unittest
+from stacker.context import Context
+from stacker.variables import Variable
+from stacker_blueprints.sns import Topics
+from stacker.blueprints.testutil import BlueprintTestCase
+
+class TestBlueprint(BlueprintTestCase):
+    def setUp(self):
+        self.variables = [
+            Variable('Topics', {
+                'Example': {
+                    'DisplayName': 'ExampleTopic',
+                    'Subscription': [
+                        {
+                            'Endpoint': 'arn:aws:sqs:us-east-1:123456788901:example-queue',
+                            'Protocol': 'sqs',
+                        },
+                        {
+                            'Endpoint': 'postmaster@example.com',
+                            'Protocol': 'email',
+                        },
+                    ]
+                },
+            }),
+        ]
+
+    def test_sns(self):
+        ctx = Context({'namespace': 'test', 'environment': 'test'})
+        blueprint = Topics('topics', ctx)
+        blueprint.resolve_variables(self.variables)
+        blueprint.create_template()
+        self.assertRenderedBlueprint(blueprint)


### PR DESCRIPTION
sns.py tries to create an sqs policy for each subscription,
regardless of Protocol; which fails for subscriptions with protocol
other than "sqs".

Fix this by creating the policy only for sqs-type topic subscriptions.

Includes a test for sns.Topics.