### PR TITLE
Fix issue with topics with no subscriptions

### DIFF
--- a/stacker_blueprints/sns.py
+++ b/stacker_blueprints/sns.py
@@ -113,7 +113,7 @@ class Topics(Blueprint):
         """
         Creates the SNS topic, along with any subscriptions requested.
         """
-        topic_subs = None
+        topic_subs = []
         t = self.template
 
         if "Subscription" in topic_config:

--- a/tests/fixtures/blueprints/topics.json
+++ b/tests/fixtures/blueprints/topics.json
@@ -12,6 +12,19 @@
                     "TopicName"
                 ]
             }
+        }, 
+        "WithoutSubscriptionArn": {
+            "Value": {
+                "Ref": "WithoutSubscription"
+            }
+        }, 
+        "WithoutSubscriptionName": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "WithoutSubscription", 
+                    "TopicName"
+                ]
+            }
         }
     }, 
     "Resources": {
@@ -59,6 +72,12 @@
                 ]
             }, 
             "Type": "AWS::SQS::QueuePolicy"
+        }, 
+        "WithoutSubscription": {
+            "Properties": {
+                "DisplayName": "SampleTopicWithoutSub"
+            }, 
+            "Type": "AWS::SNS::Topic"
         }
     }
 }

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -8,6 +8,9 @@ class TestBlueprint(BlueprintTestCase):
     def setUp(self):
         self.variables = [
             Variable('Topics', {
+                'WithoutSubscription': {
+                    'DisplayName': 'SampleTopicWithoutSub',
+                },
                 'Example': {
                     'DisplayName': 'ExampleTopic',
                     'Subscription': [


### PR DESCRIPTION
Fix an issue introduced in f4f2edb. sns.py will try to iterate
the subscriptions as a list, but when it's not specified,
topic_subs defaults to None. Default instead to [] so it can always
be iterated as a list.

Fixes #152.