### PR TITLE
Allow multiple bucket policies

### DIFF
--- a/stacker_blueprints/s3.py
+++ b/stacker_blueprints/s3.py
@@ -62,7 +62,7 @@ class Buckets(Blueprint):
             if "WebsiteConfiguration" in attrs:
                 t.add_resource(
                     s3.BucketPolicy(
-                        "BucketPolicy",
+                        "%sBucketPolicy" % title,
                         Bucket=bucket_id,
                         PolicyDocument=static_website_bucket_policy(bucket_id),
                     )

--- a/tests/fixtures/blueprints/s3_static_website.json
+++ b/tests/fixtures/blueprints/s3_static_website.json
@@ -44,7 +44,7 @@
             }, 
             "Type": "AWS::S3::Bucket"
         }, 
-        "BucketPolicy": {
+        "BlogBucketPolicy": {
             "Properties": {
                 "Bucket": {
                     "Ref": "Blog"


### PR DESCRIPTION
Without this, if you had more than one bucket defined with a website
configuration the blueprint would throw an exception because you would
try to add multiple bucket policies all with the same name (BucketPolicy)