### PR TITLE
Replace get_fqn references with AWS::StackName

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,10 @@ from setuptools import setup, find_packages
 src_dir = os.path.dirname(__file__)
 
 install_requires = [
+    # See thread here:
+    # https://remind.slack.com/archives/C03GHL501/p1520983157000263
+    # Hope to remove lock on python-dateutil someday
+    "python-dateutil==2.6.1",
     "stacker>=1.0.1",
     "troposphere>=1.9.5",
     "awacs>=0.6.0",

--- a/stacker_blueprints/aws_lambda.py
+++ b/stacker_blueprints/aws_lambda.py
@@ -10,6 +10,7 @@ from troposphere import (
     NoValue,
     Output,
     Ref,
+    Sub,
     iam,
 )
 
@@ -260,12 +261,11 @@ class Function(Blueprint):
 
     def create_policy(self):
         t = self.template
-        policy_prefix = self.context.get_fqn(self.name)
 
         self.policy = t.add_resource(
             iam.PolicyType(
                 "Policy",
-                PolicyName="%s-policy" % policy_prefix,
+                PolicyName=Sub("${AWS::StackName}-policy"),
                 PolicyDocument=Policy(
                     Statement=self.generate_policy_statements()
                 ),
@@ -289,10 +289,9 @@ class Function(Blueprint):
 
         if self.get_variables()["VpcConfig"]:
             # allow this Lambda to modify ENIs to allow it to run in our VPC.
-            policy_prefix = self.context.get_fqn(self.name)
             self.role.Policies = [
                 iam.Policy(
-                    PolicyName="%s-vpc-policy" % policy_prefix,
+                    PolicyName=Sub("${AWS::StackName}-vpc-policy"),
                     PolicyDocument=Policy(
                         Statement=lambda_vpc_execution_statements()
                     ),
@@ -374,8 +373,8 @@ class Function(Blueprint):
         if mapping:
             if "FunctionName" in mapping:
                 logger.warn(
-                    "FunctionName defined in EventSourceMapping in "
-                    "%s. Overriding.", self.context.get_fqn(self.name)
+                    Sub("FunctionName defined in EventSourceMapping in "
+                        "${AWS::StackName}. Overriding.")
                 )
             mapping["FunctionName"] = self.function.GetAtt("Arn")
             resource = t.add_resource(

--- a/stacker_blueprints/firehose/base.py
+++ b/stacker_blueprints/firehose/base.py
@@ -23,6 +23,7 @@ from troposphere import (
     GetAtt,
     Output,
     Ref,
+    Sub,
 )
 
 from ..policies import (
@@ -214,9 +215,8 @@ class BaseDeliveryStream(Blueprint):
         return statements
 
     def generate_iam_policy(self):
-        name_prefix = self.context.get_fqn(self.name)
         return iam.Policy(
-            PolicyName="{}-policy".format(name_prefix),
+            PolicyName=Sub("${AWS::StackName}-policy"),
             PolicyDocument=Policy(
                 Statement=self.generate_iam_policy_statements()
             )

--- a/stacker_blueprints/iam_roles.py
+++ b/stacker_blueprints/iam_roles.py
@@ -4,6 +4,7 @@ from troposphere import (
     GetAtt,
     Output,
     Ref,
+    Sub,
     iam,
 )
 
@@ -78,12 +79,11 @@ class Roles(Blueprint):
             return
 
         t = self.template
-        policy_prefix = self.context.get_fqn(self.name)
 
         policy = t.add_resource(
             iam.PolicyType(
                 "{}Policy".format(name),
-                PolicyName="{}-{}-policy".format(policy_prefix, name),
+                PolicyName=Sub("${AWS::StackName}-${Name}-policy", Name=name),
                 PolicyDocument=Policy(
                     Statement=statements,
                 ),

--- a/stacker_blueprints/s3.py
+++ b/stacker_blueprints/s3.py
@@ -3,6 +3,7 @@ from troposphere import (
     FindInMap,
     GetAtt,
     Output,
+    Sub,
     Ref,
     Region,
     s3,
@@ -66,8 +67,6 @@ class Buckets(Blueprint):
         t = self.template
         variables = self.get_variables()
 
-        policy_prefix = self.context.get_fqn(self.name)
-
         bucket_ids = []
 
         for title, attrs in variables["Buckets"].items():
@@ -113,7 +112,7 @@ class Buckets(Blueprint):
             t.add_resource(
                 iam.PolicyType(
                     "ReadWritePolicy",
-                    PolicyName=policy_prefix + "ReadWritePolicy",
+                    PolicyName=Sub("${AWS::StackName}ReadWritePolicy"),
                     PolicyDocument=read_write_s3_bucket_policy(
                         bucket_ids
                     ),
@@ -126,7 +125,7 @@ class Buckets(Blueprint):
             t.add_resource(
                 iam.PolicyType(
                     "ReadPolicy",
-                    PolicyName=policy_prefix + "ReadPolicy",
+                    PolicyName=Sub("${AWS::StackName}ReadPolicy"),
                     PolicyDocument=read_only_s3_bucket_policy(
                         bucket_ids
                     ),

--- a/tests/fixtures/blueprints/buckets.json
+++ b/tests/fixtures/blueprints/buckets.json
@@ -129,7 +129,9 @@
                         }
                     ]
                 }, 
-                "PolicyName": "test-bucketsReadPolicy", 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}ReadPolicy"
+                }, 
                 "Roles": [
                     "Role1", 
                     "Role2"
@@ -215,7 +217,9 @@
                         }
                     ]
                 }, 
-                "PolicyName": "test-bucketsReadWritePolicy", 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}ReadWritePolicy"
+                }, 
                 "Roles": [
                     "Role3", 
                     "Role4"

--- a/tests/fixtures/blueprints/kms_key_a.json
+++ b/tests/fixtures/blueprints/kms_key_a.json
@@ -4,78 +4,78 @@
             "Value": {
                 "Ref": "Alias"
             }
-        },
+        }, 
         "KeyArn": {
             "Value": {
                 "Fn::Join": [
-                    "",
+                    "", 
                     [
-                        "arn:aws:kms:",
+                        "arn:aws:kms:", 
                         {
                             "Ref": "AWS::Region"
-                        },
-                        ":",
+                        }, 
+                        ":", 
                         {
                             "Ref": "AWS::AccountId"
-                        },
-                        ":key/",
+                        }, 
+                        ":key/", 
                         {
                             "Ref": "Key"
                         }
                     ]
                 ]
             }
-        },
+        }, 
         "KeyId": {
             "Value": {
                 "Ref": "Key"
             }
         }
-    },
+    }, 
     "Resources": {
         "Alias": {
             "Properties": {
-                "AliasName": "alias/a-test-key",
+                "AliasName": "alias/a-test-key", 
                 "TargetKeyId": {
                     "Ref": "Key"
                 }
-            },
+            }, 
             "Type": "AWS::KMS::Alias"
-        },
+        }, 
         "Key": {
             "Properties": {
-                "Description": "a KMS test-key.",
+                "Description": "a KMS test-key.", 
                 "KeyPolicy": {
-                    "Id": "root-account-access",
+                    "Id": "root-account-access", 
                     "Statement": [
                         {
                             "Action": [
                                 "kms:*"
-                            ],
-                            "Effect": "Allow",
+                            ], 
+                            "Effect": "Allow", 
                             "Principal": {
                                 "AWS": {
                                     "Fn::Join": [
-                                        ":",
+                                        ":", 
                                         [
-                                            "arn:aws:iam:",
+                                            "arn:aws:iam:", 
                                             {
                                                 "Ref": "AWS::AccountId"
-                                            },
+                                            }, 
                                             "root"
                                         ]
                                     ]
                                 }
-                            },
+                            }, 
                             "Resource": [
                                 "*"
-                            ],
+                            ], 
                             "Sid": "Enable IAM User Permissions"
                         }
-                    ],
+                    ], 
                     "Version": "2012-10-17"
                 }
-            },
+            }, 
             "Type": "AWS::KMS::Key"
         }
     }

--- a/tests/fixtures/blueprints/kms_key_b.json
+++ b/tests/fixtures/blueprints/kms_key_b.json
@@ -4,78 +4,78 @@
             "Value": {
                 "Ref": "Alias"
             }
-        },
+        }, 
         "KeyArn": {
             "Value": {
                 "Fn::Join": [
-                    "",
+                    "", 
                     [
-                        "arn:aws:kms:",
+                        "arn:aws:kms:", 
                         {
                             "Ref": "AWS::Region"
-                        },
-                        ":",
+                        }, 
+                        ":", 
                         {
                             "Ref": "AWS::AccountId"
-                        },
-                        ":key/",
+                        }, 
+                        ":key/", 
                         {
                             "Ref": "Key"
                         }
                     ]
                 ]
             }
-        },
+        }, 
         "KeyId": {
             "Value": {
                 "Ref": "Key"
             }
         }
-    },
+    }, 
     "Resources": {
         "Alias": {
             "Properties": {
-                "AliasName": "alias/b-test-key",
+                "AliasName": "alias/b-test-key", 
                 "TargetKeyId": {
                     "Ref": "Key"
                 }
-            },
+            }, 
             "Type": "AWS::KMS::Alias"
-        },
+        }, 
         "Key": {
             "Properties": {
-                "Description": "b KMS test-key.",
+                "Description": "b KMS test-key.", 
                 "KeyPolicy": {
-                    "Id": "root-account-access",
+                    "Id": "root-account-access", 
                     "Statement": [
                         {
                             "Action": [
                                 "kms:*"
-                            ],
-                            "Effect": "Allow",
+                            ], 
+                            "Effect": "Allow", 
                             "Principal": {
                                 "AWS": {
                                     "Fn::Join": [
-                                        ":",
+                                        ":", 
                                         [
-                                            "arn:aws:iam:",
+                                            "arn:aws:iam:", 
                                             {
                                                 "Ref": "AWS::AccountId"
-                                            },
+                                            }, 
                                             "root"
                                         ]
                                     ]
                                 }
-                            },
+                            }, 
                             "Resource": [
                                 "*"
-                            ],
+                            ], 
                             "Sid": "Enable IAM User Permissions"
                         }
-                    ],
+                    ], 
                     "Version": "2012-10-17"
                 }
-            },
+            }, 
             "Type": "AWS::KMS::Key"
         }
     }

--- a/tests/fixtures/blueprints/kms_key_c.json
+++ b/tests/fixtures/blueprints/kms_key_c.json
@@ -4,77 +4,77 @@
             "Value": {
                 "Ref": "Alias"
             }
-        },
+        }, 
         "KeyArn": {
             "Value": {
                 "Fn::Join": [
-                    "",
+                    "", 
                     [
-                        "arn:aws:kms:",
+                        "arn:aws:kms:", 
                         {
                             "Ref": "AWS::Region"
-                        },
-                        ":",
+                        }, 
+                        ":", 
                         {
                             "Ref": "AWS::AccountId"
-                        },
-                        ":key/",
+                        }, 
+                        ":key/", 
                         {
                             "Ref": "Key"
                         }
                     ]
                 ]
             }
-        },
+        }, 
         "KeyId": {
             "Value": {
                 "Ref": "Key"
             }
         }
-    },
+    }, 
     "Resources": {
         "Alias": {
             "Properties": {
-                "AliasName": "alias/c-test-key",
+                "AliasName": "alias/c-test-key", 
                 "TargetKeyId": {
                     "Ref": "Key"
                 }
-            },
+            }, 
             "Type": "AWS::KMS::Alias"
-        },
+        }, 
         "Key": {
             "Properties": {
                 "KeyPolicy": {
-                    "Id": "root-account-access",
+                    "Id": "root-account-access", 
                     "Statement": [
                         {
                             "Action": [
                                 "kms:*"
-                            ],
-                            "Effect": "Allow",
+                            ], 
+                            "Effect": "Allow", 
                             "Principal": {
                                 "AWS": {
                                     "Fn::Join": [
-                                        ":",
+                                        ":", 
                                         [
-                                            "arn:aws:iam:",
+                                            "arn:aws:iam:", 
                                             {
                                                 "Ref": "AWS::AccountId"
-                                            },
+                                            }, 
                                             "root"
                                         ]
                                     ]
                                 }
-                            },
+                            }, 
                             "Resource": [
                                 "*"
-                            ],
+                            ], 
                             "Sid": "Enable IAM User Permissions"
                         }
-                    ],
+                    ], 
                     "Version": "2012-10-17"
                 }
-            },
+            }, 
             "Type": "AWS::KMS::Key"
         }
     }

--- a/tests/fixtures/blueprints/queues.json
+++ b/tests/fixtures/blueprints/queues.json
@@ -3,67 +3,67 @@
         "FifoArn": {
             "Value": {
                 "Fn::GetAtt": [
-                    "Fifo",
+                    "Fifo", 
                     "Arn"
                 ]
             }
-        },
+        }, 
         "FifoUrl": {
             "Value": {
                 "Ref": "Fifo"
             }
-        },
+        }, 
         "RedrivePolicyArn": {
             "Value": {
                 "Fn::GetAtt": [
-                    "RedrivePolicy",
+                    "RedrivePolicy", 
                     "Arn"
                 ]
             }
-        },
+        }, 
         "RedrivePolicyUrl": {
             "Value": {
                 "Ref": "RedrivePolicy"
             }
-        },
+        }, 
         "SimpleArn": {
             "Value": {
                 "Fn::GetAtt": [
-                    "Simple",
+                    "Simple", 
                     "Arn"
                 ]
             }
-        },
+        }, 
         "SimpleUrl": {
             "Value": {
                 "Ref": "Simple"
             }
         }
-    },
+    }, 
     "Resources": {
         "Fifo": {
             "Properties": {
-                "FifoQueue": true,
+                "FifoQueue": true, 
                 "QueueName": "Fifo.fifo"
-            },
+            }, 
             "Type": "AWS::SQS::Queue"
-        },
+        }, 
         "RedrivePolicy": {
             "Properties": {
                 "RedrivePolicy": {
-                    "deadLetterTargetArn": "arn:aws:sqs:us-east-1:123456789:dlq",
+                    "deadLetterTargetArn": "arn:aws:sqs:us-east-1:123456789:dlq", 
                     "maxReceiveCount": 3
                 }
-            },
+            }, 
             "Type": "AWS::SQS::Queue"
-        },
+        }, 
         "Simple": {
             "Properties": {
-                "DelaySeconds": 15,
-                "MaximumMessageSize": 4096,
-                "ReceiveMessageWaitTimeSeconds": 15,
+                "DelaySeconds": 15, 
+                "MaximumMessageSize": 4096, 
+                "ReceiveMessageWaitTimeSeconds": 15, 
                 "VisibilityTimeout": 600
-            },
+            }, 
             "Type": "AWS::SQS::Queue"
         }
     }

--- a/tests/fixtures/blueprints/route53_dnsrecords.json
+++ b/tests/fixtures/blueprints/route53_dnsrecords.json
@@ -3,28 +3,28 @@
         "HostedZoneId": {
             "Value": "fake_zone_id"
         }
-    },
+    }, 
     "Resources": {
         "154ad64949b7d01dc1d117e306f5ef2c": {
             "Properties": {
-                "HostedZoneId": "fake_zone_id",
-                "Name": "host2.testdomain.com.",
+                "HostedZoneId": "fake_zone_id", 
+                "Name": "host2.testdomain.com.", 
                 "ResourceRecords": [
                     "10.0.0.2"
-                ],
+                ], 
                 "Type": "A"
-            },
+            }, 
             "Type": "AWS::Route53::RecordSet"
-        },
+        }, 
         "d8df5bad0c9f04ee2c1f12f25a46a67c": {
             "Properties": {
-                "HostedZoneId": "fake_zone_id",
-                "Name": "host.testdomain.com.",
+                "HostedZoneId": "fake_zone_id", 
+                "Name": "host.testdomain.com.", 
                 "ResourceRecords": [
                     "10.0.0.1"
-                ],
+                ], 
                 "Type": "A"
-            },
+            }, 
             "Type": "AWS::Route53::RecordSet"
         }
     }

--- a/tests/fixtures/blueprints/route53_dnsrecords_zone_name.json
+++ b/tests/fixtures/blueprints/route53_dnsrecords_zone_name.json
@@ -4,56 +4,56 @@
             "Value": {
                 "Ref": "HostedZone"
             }
-        },
+        }, 
         "NameServers": {
             "Value": {
                 "Fn::Join": [
-                    ",",
+                    ",", 
                     {
                         "Fn::GetAtt": [
-                            "HostedZone",
+                            "HostedZone", 
                             "NameServers"
                         ]
                     }
                 ]
             }
         }
-    },
+    }, 
     "Resources": {
         "154ad64949b7d01dc1d117e306f5ef2c": {
             "Properties": {
-                "Comment": "This is host2's record. : )",
+                "Comment": "This is host2's record. : )", 
                 "HostedZoneId": {
                     "Ref": "HostedZone"
-                },
-                "Name": "host2.testdomain.com.",
+                }, 
+                "Name": "host2.testdomain.com.", 
                 "ResourceRecords": [
                     "10.0.0.2"
-                ],
+                ], 
                 "Type": "A"
-            },
+            }, 
             "Type": "AWS::Route53::RecordSet"
-        },
+        }, 
         "HostedZone": {
             "Properties": {
                 "HostedZoneConfig": {
                     "Comment": "test-testdomain-com"
-                },
+                }, 
                 "Name": "testdomain.com"
-            },
+            }, 
             "Type": "AWS::Route53::HostedZone"
-        },
+        }, 
         "d8df5bad0c9f04ee2c1f12f25a46a67c": {
             "Properties": {
                 "HostedZoneId": {
                     "Ref": "HostedZone"
-                },
-                "Name": "host.testdomain.com.",
+                }, 
+                "Name": "host.testdomain.com.", 
                 "ResourceRecords": [
                     "10.0.0.1"
-                ],
+                ], 
                 "Type": "A"
-            },
+            }, 
             "Type": "AWS::Route53::RecordSet"
         }
     }

--- a/tests/fixtures/blueprints/s3_static_website.json
+++ b/tests/fixtures/blueprints/s3_static_website.json
@@ -179,7 +179,9 @@
                         }
                     ]
                 }, 
-                "PolicyName": "test-s3_static_websiteReadPolicy", 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}ReadPolicy"
+                }, 
                 "Roles": [
                     "Role1", 
                     "Role2"
@@ -245,7 +247,9 @@
                         }
                     ]
                 }, 
-                "PolicyName": "test-s3_static_websiteReadWritePolicy", 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}ReadWritePolicy"
+                }, 
                 "Roles": [
                     "Role3", 
                     "Role4"

--- a/tests/fixtures/blueprints/test_aws_lambda_Function.json
+++ b/tests/fixtures/blueprints/test_aws_lambda_Function.json
@@ -157,7 +157,9 @@
                         }
                     ]
                 }, 
-                "PolicyName": "test-test_aws_lambda_Function-policy", 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}-policy"
+                }, 
                 "Roles": [
                     {
                         "Ref": "Role"

--- a/tests/fixtures/blueprints/test_aws_lambda_FunctionScheduler.json
+++ b/tests/fixtures/blueprints/test_aws_lambda_FunctionScheduler.json
@@ -2,30 +2,30 @@
     "Resources": {
         "MyTestFuncSchedule": {
             "Properties": {
-                "Description": "The AWS Lambda schedule for my-powerful-test-function",
-                "ScheduleExpression": "rate(15 minutes)",
-                "State": "ENABLED",
+                "Description": "The AWS Lambda schedule for my-powerful-test-function", 
+                "ScheduleExpression": "rate(15 minutes)", 
+                "State": "ENABLED", 
                 "Targets": [
                     {
-                        "Arn": "arn:aws:lambda:us-east-1:01234:function:my-Function-162L1234",
+                        "Arn": "arn:aws:lambda:us-east-1:01234:function:my-Function-162L1234", 
                         "Id": "my-powerful-test-function"
                     }
                 ]
-            },
+            }, 
             "Type": "AWS::Events::Rule"
-        },
+        }, 
         "PermToInvokeFunctionForMyPowerfulTestFunction": {
             "Properties": {
-                "Action": "lambda:InvokeFunction",
-                "FunctionName": "arn:aws:lambda:us-east-1:01234:function:my-Function-162L1234",
-                "Principal": "events.amazonaws.com",
+                "Action": "lambda:InvokeFunction", 
+                "FunctionName": "arn:aws:lambda:us-east-1:01234:function:my-Function-162L1234", 
+                "Principal": "events.amazonaws.com", 
                 "SourceArn": {
                     "Fn::GetAtt": [
-                        "MyTestFuncSchedule",
+                        "MyTestFuncSchedule", 
                         "Arn"
                     ]
                 }
-            },
+            }, 
             "Type": "AWS::Lambda::Permission"
         }
     }

--- a/tests/fixtures/blueprints/test_aws_lambda_Function_event_source_mapping.json
+++ b/tests/fixtures/blueprints/test_aws_lambda_Function_event_source_mapping.json
@@ -195,7 +195,9 @@
                         }
                     ]
                 }, 
-                "PolicyName": "test-test_aws_lambda_Function_event_source_mapping-policy", 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}-policy"
+                }, 
                 "Roles": [
                     {
                         "Ref": "Role"

--- a/tests/fixtures/blueprints/test_aws_lambda_Function_extended_statements.json
+++ b/tests/fixtures/blueprints/test_aws_lambda_Function_extended_statements.json
@@ -166,7 +166,9 @@
                         }
                     ]
                 }, 
-                "PolicyName": "test-test_aws_lambda_Function_extended_statements-policy", 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}-policy"
+                }, 
                 "Roles": [
                     {
                         "Ref": "Role"

--- a/tests/fixtures/blueprints/test_aws_lambda_Function_with_alias_full_name_arn.json
+++ b/tests/fixtures/blueprints/test_aws_lambda_Function_with_alias_full_name_arn.json
@@ -172,7 +172,9 @@
                         }
                     ]
                 }, 
-                "PolicyName": "test-test_aws_lambda_Function_with_alias_full_name_arn-policy", 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}-policy"
+                }, 
                 "Roles": [
                     {
                         "Ref": "Role"

--- a/tests/fixtures/blueprints/test_aws_lambda_Function_with_alias_partial_name.json
+++ b/tests/fixtures/blueprints/test_aws_lambda_Function_with_alias_partial_name.json
@@ -172,7 +172,9 @@
                         }
                     ]
                 }, 
-                "PolicyName": "test-test_aws_lambda_Function_with_alias_partial_name-policy", 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}-policy"
+                }, 
                 "Roles": [
                     {
                         "Ref": "Role"

--- a/tests/fixtures/blueprints/test_aws_lambda_Function_with_alias_provided_version.json
+++ b/tests/fixtures/blueprints/test_aws_lambda_Function_with_alias_provided_version.json
@@ -172,7 +172,9 @@
                         }
                     ]
                 }, 
-                "PolicyName": "test-test_aws_lambda_Function_with_alias_provided_version-policy", 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}-policy"
+                }, 
                 "Roles": [
                     {
                         "Ref": "Role"

--- a/tests/fixtures/blueprints/test_aws_lambda_Function_with_vpc_config.json
+++ b/tests/fixtures/blueprints/test_aws_lambda_Function_with_vpc_config.json
@@ -166,7 +166,9 @@
                         }
                     ]
                 }, 
-                "PolicyName": "test-test_aws_lambda_Function_with_vpc_config-policy", 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}-policy"
+                }, 
                 "Roles": [
                     {
                         "Ref": "Role"
@@ -209,7 +211,9 @@
                                 }
                             ]
                         }, 
-                        "PolicyName": "test-test_aws_lambda_Function_with_vpc_config-vpc-policy"
+                        "PolicyName": {
+                            "Fn::Sub": "${AWS::StackName}-vpc-policy"
+                        }
                     }
                 ]
             }, 

--- a/tests/fixtures/blueprints/test_cloudwatch_logs_subscription_filters.json
+++ b/tests/fixtures/blueprints/test_cloudwatch_logs_subscription_filters.json
@@ -4,42 +4,42 @@
             "Value": {
                 "Ref": "Filter1"
             }
-        },
+        }, 
         "Filter2Name": {
             "Value": {
                 "Ref": "Filter2"
             }
         }
-    },
+    }, 
     "Resources": {
         "Filter1": {
             "Properties": {
                 "DestinationArn": {
                     "Fn::GetAtt": [
-                        "KinesisStream1",
+                        "KinesisStream1", 
                         "Arn"
                     ]
-                },
-                "FilterPattern": "{$.userIdentity.type = Root}",
+                }, 
+                "FilterPattern": "{$.userIdentity.type = Root}", 
                 "LogGroupName": {
                     "Ref": "LogGroup1"
                 }
-            },
+            }, 
             "Type": "AWS::Logs::SubscriptionFilter"
-        },
+        }, 
         "Filter2": {
             "Properties": {
                 "DestinationArn": {
                     "Fn::GetAtt": [
-                        "KinesisStream2",
+                        "KinesisStream2", 
                         "Arn"
                     ]
-                },
-                "FilterPattern": "{$.userIdentity.type = Root}",
+                }, 
+                "FilterPattern": "{$.userIdentity.type = Root}", 
                 "LogGroupName": {
                     "Ref": "LogGroup2"
                 }
-            },
+            }, 
             "Type": "AWS::Logs::SubscriptionFilter"
         }
     }

--- a/tests/fixtures/blueprints/test_generic_GenericResourceCreator.json
+++ b/tests/fixtures/blueprints/test_generic_GenericResourceCreator.json
@@ -1,22 +1,22 @@
 {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "Generic Resource Creator - 1.0.0",
+    "AWSTemplateFormatVersion": "2010-09-09", 
+    "Description": "Generic Resource Creator - 1.0.0", 
     "Outputs": {
         "VolumeId": {
-            "Description": "A reference to the object created in this blueprint",
+            "Description": "A reference to the object created in this blueprint", 
             "Value": {
                 "Ref": "ResourceRefName"
             }
         }
-    },
+    }, 
     "Resources": {
         "ResourceRefName": {
             "Properties": {
-                "AvailabilityZone": "us-east-1b",
-                "Encrypted": "true",
-                "Size": "600",
+                "AvailabilityZone": "us-east-1b", 
+                "Encrypted": "true", 
+                "Size": "600", 
                 "VolumeType": "gp2"
-            },
+            }, 
             "Type": "AWS::EC2::Volume"
         }
     }


### PR DESCRIPTION
`get_fqn` relies on stacker internals, and can change if you ever change the top level namespace of your config. AWS::StackName effectively solves the same problem, and won't change out from under you.

Note, I left `get_fqn` in [stacker_blueprints/rds/base.py](https://github.com/remind101/stacker_blueprints/blob/073e0c71aa6d552046e8b5099e50a79a8a5a7b47/stacker_blueprints/rds/base.py#L414) because changing it would break backwards compatibility. Everything else is just IAM policy names, which can be updated without issue.