### PR TITLE
Remove UseNatInstances Condition

### DIFF
--- a/stacker_blueprints/vpc.py
+++ b/stacker_blueprints/vpc.py
@@ -352,7 +352,6 @@ class VPC(Blueprint):
             t.add_resource(
                 ec2.Instance(
                     instance_name,
-                    Condition="UseNatInstances",
                     ImageId=image_id,
                     SecurityGroupIds=[Ref(DEFAULT_SG), Ref(NAT_SG)],
                     SubnetId=Ref(subnet_name),


### PR DESCRIPTION
This was leftover after we moved from using Conditions to using stacker
variables it looks like, makes it so you can't actually use
NatInstances.