### PR TITLE
Restructuring DynamoDB Autoscaling schema after learning more about problem.

### DIFF
--- a/stacker_blueprints/policies.py
+++ b/stacker_blueprints/policies.py
@@ -37,6 +37,14 @@ def make_simple_assume_policy(*principals):
             make_simple_assume_statement(*principals)])
 
 
+def dynamodb_arn(table_name):
+    return 'arn:aws:dynamodb:::table/{}'.format(table_name)
+
+
+def dynamodb_arns(table_names):
+    return [dynamodb_arn(table_name) for table_name in table_names]
+
+
 def s3_arn(bucket):
     if isinstance(bucket, AWSHelperFn):
         return Sub('arn:aws:s3:::${Bucket}', Bucket=bucket)
@@ -217,7 +225,7 @@ def dynamodb_autoscaling_policy(tables):
         Statement=[
             Statement(
                 Effect=Allow,
-                Resource=tables,
+                Resource=dynamodb_arns(tables),
                 Action=[
                     dynamodb.DescribeTable,
                     dynamodb.UpdateTable,

--- a/tests/fixtures/blueprints/dynamodb_autoscaling.json
+++ b/tests/fixtures/blueprints/dynamodb_autoscaling.json
@@ -28,8 +28,8 @@
                                     ], 
                                     "Effect": "Allow", 
                                     "Resource": [
-                                        "test-user-table", 
-                                        "test-group-table"
+                                        "arn:aws:dynamodb:::table/test-user-table", 
+                                        "arn:aws:dynamodb:::table/test-group-table"
                                     ]
                                 }, 
                                 {
@@ -77,9 +77,12 @@
             "Properties": {
                 "MaxCapacity": 50, 
                 "MinCapacity": 10, 
-                "ResourceId": "test-group-table", 
+                "ResourceId": "table/test-group-table", 
                 "RoleARN": {
-                    "Ref": "Role"
+                    "Fn::GetAtt": [
+                        "Role", 
+                        "Arn"
+                    ]
                 }, 
                 "ScalableDimension": "dynamodb:table:ReadCapacityUnits", 
                 "ServiceNamespace": "dynamodb"
@@ -97,8 +100,8 @@
                     "PredefinedMetricSpecification": {
                         "PredefinedMetricType": "DynamoDBWriteCapacityUtilization"
                     }, 
-                    "ScaleInCooldown": 180, 
-                    "ScaleOutCooldown": 180, 
+                    "ScaleInCooldown": 60, 
+                    "ScaleOutCooldown": 60, 
                     "TargetValue": 50.0
                 }
             }, 
@@ -108,9 +111,12 @@
             "Properties": {
                 "MaxCapacity": 25, 
                 "MinCapacity": 1, 
-                "ResourceId": "test-group-table", 
+                "ResourceId": "table/test-group-table", 
                 "RoleARN": {
-                    "Ref": "Role"
+                    "Fn::GetAtt": [
+                        "Role", 
+                        "Arn"
+                    ]
                 }, 
                 "ScalableDimension": "dynamodb:table:WriteCapacityUnits", 
                 "ServiceNamespace": "dynamodb"
@@ -139,9 +145,12 @@
             "Properties": {
                 "MaxCapacity": 100, 
                 "MinCapacity": 5, 
-                "ResourceId": "test-user-table", 
+                "ResourceId": "table/test-user-table", 
                 "RoleARN": {
-                    "Ref": "Role"
+                    "Fn::GetAtt": [
+                        "Role", 
+                        "Arn"
+                    ]
                 }, 
                 "ScalableDimension": "dynamodb:table:ReadCapacityUnits", 
                 "ServiceNamespace": "dynamodb"
@@ -161,7 +170,7 @@
                     }, 
                     "ScaleInCooldown": 60, 
                     "ScaleOutCooldown": 60, 
-                    "TargetValue": 75.0
+                    "TargetValue": 80.0
                 }
             }, 
             "Type": "AWS::ApplicationAutoScaling::ScalingPolicy"
@@ -170,9 +179,12 @@
             "Properties": {
                 "MaxCapacity": 50, 
                 "MinCapacity": 5, 
-                "ResourceId": "test-user-table", 
+                "ResourceId": "table/test-user-table", 
                 "RoleARN": {
-                    "Ref": "Role"
+                    "Fn::GetAtt": [
+                        "Role", 
+                        "Arn"
+                    ]
                 }, 
                 "ScalableDimension": "dynamodb:table:WriteCapacityUnits", 
                 "ServiceNamespace": "dynamodb"

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -50,20 +50,13 @@ class TestDynamoDB(BlueprintTestCase):
               [
                   {
                       "table": "test-user-table",
-                      "capacity": {
-                          "read" : [5, 100],
-                          "write" : [5, 50],
-                      },
-                      "target-value": 75.0,
+                      "read": {"min": 5, "max": 100, "target": 75.0},
+                      "write": {"min": 5, "max": 50, "target": 80.0},
                   },
                   {
                       "table": "test-group-table",
-                      "capacity": {
-                          "read" : [10, 50],
-                          "write" : [1, 25],
-                      },
-                      "scale-in-cooldown": 180,
-                      "scale-out-cooldown": 180,
+                      "read": {"min": 10, "max": 50, "scale-in-cooldown": 180, "scale-out-cooldown": 180},
+                      "write": {"max": 25},
                   },
               ]
             )


### PR DESCRIPTION
Firstly the IAM permissions expect a list of ARNs, not table names.

Secondly, we need to make target and scale-in/out cooldowns configurable per capacity_type.

	modified:   stacker_blueprints/dynamodb.py
	modified:   stacker_blueprints/policies.py
	modified:   tests/fixtures/blueprints/dynamodb_autoscaling.json
	modified:   tests/test_dynamodb.py