### PR TITLE
Support route53.RecordSetGroup's

### DIFF
--- a/tests/fixtures/blueprints/route53_record_set_groups.json
+++ b/tests/fixtures/blueprints/route53_record_set_groups.json
@@ -1,0 +1,35 @@
+{
+    "Outputs": {
+        "HostedZoneId": {
+            "Value": "fake_zone_id"
+        }
+    }, 
+    "Resources": {
+        "Frontend": {
+            "Properties": {
+                "HostedZoneId": "fake_zone_id", 
+                "RecordSets": [
+                    {
+                        "Name": "mysite.example.com", 
+                        "ResourceRecords": [
+                            "example-ec2.amazonaws.com"
+                        ], 
+                        "SetIdentifier": "Frontend One", 
+                        "Type": "CNAME", 
+                        "Weight": "4"
+                    }, 
+                    {
+                        "Name": "mysite.example.com", 
+                        "ResourceRecords": [
+                            "example-ec2-larger.amazonaws.com"
+                        ], 
+                        "SetIdentifier": "Frontend Two", 
+                        "Type": "CNAME", 
+                        "Weight": "6"
+                    }
+                ]
+            }, 
+            "Type": "AWS::Route53::RecordSetGroup"
+        }
+    }
+}

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -39,6 +39,39 @@ class TestRoute53(BlueprintTestCase):
         blueprint.create_template()
         self.assertRenderedBlueprint(blueprint)
 
+    def test_create_template_record_set_grroup(self):
+        blueprint = DNSRecords('route53_record_set_groups', self.ctx)
+        blueprint.resolve_variables(
+            [
+                Variable(
+                    "RecordSetGroups",
+                    {
+                        "Frontend": {
+                            "RecordSets": [
+                                {
+                                    "Name": "mysite.example.com",
+                                    "Type": "CNAME",
+                                    "SetIdentifier": "Frontend One",
+                                    "Weight": "4",
+                                    "ResourceRecords": ["example-ec2.amazonaws.com"],
+                                },
+                                {
+                                    "Name": "mysite.example.com",
+                                    "Type": "CNAME",
+                                    "SetIdentifier": "Frontend Two",
+                                    "Weight": "6",
+                                    "ResourceRecords": ["example-ec2-larger.amazonaws.com"],
+                                },
+                            ]
+                        },
+                    }
+                ),
+                Variable("HostedZoneId", "fake_zone_id"),
+            ]
+        )
+        blueprint.create_template()
+        self.assertRenderedBlueprint(blueprint)
+
     def test_create_template_hosted_zone_name(self):
         blueprint = DNSRecords('route53_dnsrecords_zone_name', self.ctx)
         blueprint.resolve_variables(


### PR DESCRIPTION
This add's support for the route53.RecordSetGroup type, which can be used to setup weighted route53 records: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordsetgroup.html